### PR TITLE
refeat(phase-4): real-time serving pipeline (v0.4.0-serving-pipeline)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,15 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - name: Install package (dev + train extras, CPU-only torch)
+      - name: Install package (dev + train + serve extras, CPU-only torch)
         # The ``train`` extras pull in PyTorch. By default pip picks the
         # CUDA wheel which is ~2GB; we want the CPU wheel for CI speed.
+        # ``serve`` adds Ray Serve, confluent-kafka, SHAP, prometheus-client
+        # and websockets so the Phase 4 serving tests can import them.
         run: |
           python -m pip install --upgrade pip
           pip install --extra-index-url https://download.pytorch.org/whl/cpu "torch>=2.10,<2.11"
-          pip install -e ".[dev,train]"
+          pip install -e ".[dev,train,serve]"
 
       - name: Lint (ruff)
         run: |

--- a/Dockerfile.serving
+++ b/Dockerfile.serving
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1.7
+# Meshwatch fraud-detection serving container
+#
+# Multi-stage build keeps the runtime image small (no pip cache, no build deps).
+
+# ---------- builder ----------
+FROM python:3.11-slim-bookworm AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Build deps for shap, confluent-kafka, etc.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        gcc \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+# CPU-only torch wheel (the default CUDA wheel is ~2 GB and not needed for inference).
+RUN pip install --upgrade pip && \
+    pip install --extra-index-url https://download.pytorch.org/whl/cpu "torch>=2.10,<2.11" && \
+    pip install ".[train,serve]"
+
+# ---------- runtime ----------
+FROM python:3.11-slim-bookworm AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    FRAUD_LOG_LEVEL=INFO
+
+# Runtime deps only (librdkafka + libgomp for xgboost).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgomp1 \
+        librdkafka1 \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy installed Python packages + the project source.
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY src ./src
+COPY configs ./configs
+COPY scripts ./scripts
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl --fail --silent http://localhost:8000/api/v1/health || exit 1
+
+# Default to plain uvicorn; override with --ray for Ray Serve.
+CMD ["python", "-m", "uvicorn", "fraud_detection.serving.app:app", \
+     "--host", "0.0.0.0", "--port", "8000", "--access-log", "false"]

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,10 @@ TEST_DIR := tests
         build-graph build-graph-subset feast-apply graph-eda \
         train train-ensemble evaluate-gnn evaluate-ensemble \
         gnn-eda ensemble-eda colab-eda mlflow-ui \
+        serve serve-ray serve-dev demo-stream demo-stream-batch \
+        compose-up compose-down compose-logs docker-build-serving \
         clean clean-data clean-all \
-        tag-phase-1 tag-phase-2 tag-phase-3
+        tag-phase-1 tag-phase-2 tag-phase-3 tag-phase-4
 
 help: ## Show this help
 	@echo "Fraud Detection GNN -- common targets"
@@ -126,6 +128,39 @@ mlflow-ui: ## Launch the MLflow UI (http://localhost:5000) -- reads ./mlflow.db 
 	$(PY) -m mlflow ui --backend-store-uri sqlite:///mlflow.db
 
 # ---------------------------------------------------------------------------
+# Serving (Phase 4)
+# ---------------------------------------------------------------------------
+serve: ## Start FastAPI on http://127.0.0.1:8000 (single worker, prod-style)
+	$(PY) scripts/serve.py
+
+serve-dev: ## Start FastAPI with auto-reload (dev mode)
+	$(PY) scripts/serve.py --reload
+
+serve-ray: ## Start the API behind Ray Serve (multi-replica)
+	$(PY) scripts/serve.py --ray --num-replicas 2
+
+demo-stream: ## Replay 200 transactions at 5 RPS to /api/v1/predict
+	$(PY) scripts/demo_stream.py --n 200 --rps 5
+
+demo-stream-batch: ## Stress test: 2000 txns @ 50 RPS via /api/v1/predict/batch
+	$(PY) scripts/demo_stream.py --n 2000 --rps 50 --batch 50 --summary-only
+
+# ---------------------------------------------------------------------------
+# Docker Compose (Phase 4 infra)
+# ---------------------------------------------------------------------------
+compose-up: ## Bring up Redis + Kafka + MLflow + Prometheus + Grafana + API
+	docker compose up -d
+
+compose-down: ## Tear down compose stack (keeps named volumes)
+	docker compose down
+
+compose-logs: ## Tail logs from the API container
+	docker compose logs -f api
+
+docker-build-serving: ## Build the API image locally
+	docker build -t meshwatch/api:dev -f Dockerfile.serving .
+
+# ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
 clean: ## Remove caches and build artifacts
@@ -152,3 +187,7 @@ tag-phase-2: ## Tag v0.2.0-graph-engine
 tag-phase-3: ## Tag v0.3.0-gnn-model
 	git tag -a v0.3.0-gnn-model -m "Phase 3: GNN Model & Training"
 	@echo "Tag created. Push with: git push origin v0.3.0-gnn-model"
+
+tag-phase-4: ## Tag v0.4.0-serving-pipeline
+	git tag -a v0.4.0-serving-pipeline -m "Phase 4: Real-Time Serving Pipeline"
+	@echo "Tag created. Push with: git push origin v0.4.0-serving-pipeline"

--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@
 > Serve, and auto-investigates alerts with a LangGraph agent. A React
 > dashboard visualises the fraud network. Built on IEEE-CIS (590K transactions).
 
-[![Phase](https://img.shields.io/badge/phase-3%2F8-blue)](./Fraud_Detection_GNN_Implementation_Plan.pdf)
+[![Phase](https://img.shields.io/badge/phase-4%2F8-blue)](./Fraud_Detection_GNN_Implementation_Plan.pdf)
 [![Python](https://img.shields.io/badge/python-3.10%2B-brightgreen)]()
 [![License](https://img.shields.io/badge/license-MIT-lightgrey)]()
-[![Tests](https://img.shields.io/badge/tests-153%20passing-success)]()
+[![Tests](https://img.shields.io/badge/tests-215%20passing-success)]()
+[![Latency](https://img.shields.io/badge/predict-P95%201.6ms-success)]()
 
 Production-grade fraud detection on the **IEEE-CIS** dataset (590,540 transactions, 3.5% fraud rate)
 combining a **heterogeneous GNN** (PyTorch Geometric) with an **XGBoost ensemble**, served in
 real time (<50ms P95) via FastAPI + Ray Serve + Kafka, and investigated automatically by a
 **LangGraph agent** backed by a local Ollama LLM. Results surface in a React.js dashboard.
 
-> This repository is currently at **Phase 3: GNN Model & Training (`v0.3.0-gnn-model`)**.
+> This repository is currently at **Phase 4: Real-Time Serving Pipeline (`v0.4.0-serving-pipeline`)**.
 > See [Fraud_Detection_GNN_Implementation_Plan.pdf](./Fraud_Detection_GNN_Implementation_Plan.pdf)
 > for the complete 8-phase roadmap.
 
@@ -119,6 +120,84 @@ GNN embedding (64) + tabular features (119) → XGBoost  (n_est 500, depth 8, lr
 | MLflow UI shows experiment with metrics/params/artifacts | ✅ `make mlflow-ui`; trainer auto-logs params + per-epoch metrics |
 | Evaluation report generated with PR/ROC curves, calibration plot | ✅ `data/models/{gnn,ensemble}/eval/{val,test}_{pr,roc,calibration}.png` + `*_metrics.json` |
 
+## Phase 4 -- Real-Time Serving Pipeline (`v0.4.0-serving-pipeline`)
+
+| Area | File | Purpose |
+| --- | --- | --- |
+| Pydantic schemas | [`src/fraud_detection/serving/schemas.py`](src/fraud_detection/serving/schemas.py) | `TransactionRequest`, `FraudPrediction`, `BatchPredictResponse`, `FraudAlert`, `HealthStatus`, `ModelInfoResponse` |
+| Embedding cache | [`src/fraud_detection/serving/redis_cache.py`](src/fraud_detection/serving/redis_cache.py) | Redis-backed cache with thread-safe in-memory fallback (auto-detects on `connect()`) |
+| **Predictor** | [`src/fraud_detection/serving/predictor.py`](src/fraud_detection/serving/predictor.py) | `FraudPredictor` orchestrates: cache lookup → tabular row → GNN+XGB → SHAP. P95 = **1.6 ms** in-process |
+| Middleware | [`src/fraud_detection/serving/middleware.py`](src/fraud_detection/serving/middleware.py) | Request timing + `X-Request-ID` + Prometheus metrics (no-op if `prometheus-client` missing) |
+| **FastAPI app** | [`src/fraud_detection/serving/app.py`](src/fraud_detection/serving/app.py) | 5 REST + 1 WS endpoint; lifespan loads model + connects Redis/Kafka; degrades gracefully on every dep |
+| Ray Serve | [`src/fraud_detection/serving/ray_deployment.py`](src/fraud_detection/serving/ray_deployment.py) | Optional multi-replica deployment via `--ray` flag |
+| Kafka producer | [`src/fraud_detection/streaming/kafka_producer.py`](src/fraud_detection/streaming/kafka_producer.py) | Publishes `FraudAlert` to `fraud_alerts`; in-memory fallback when no broker |
+| Kafka consumer | [`src/fraud_detection/streaming/kafka_consumer.py`](src/fraud_detection/streaming/kafka_consumer.py) | Sync `start()` / async `consume_async()`; FastAPI lifespan fans alerts out via WS |
+| Docker Compose | [`docker-compose.yml`](docker-compose.yml) | Redis 7 + Kafka 7.6 + Zookeeper + MLflow + Prometheus + Grafana + API |
+| Serving Dockerfile | [`Dockerfile.serving`](Dockerfile.serving) | Multi-stage build, CPU-only torch wheel, healthcheck via `/api/v1/health` |
+| CLIs | [`scripts/serve.py`](scripts/serve.py), [`scripts/demo_stream.py`](scripts/demo_stream.py) | `make serve` / `make demo-stream` |
+
+### API endpoints
+
+| Method | Path | Body / output |
+| --- | --- | --- |
+| `POST` | `/api/v1/predict` | `TransactionRequest` → `FraudPrediction` |
+| `POST` | `/api/v1/predict/batch` | up to 100 `TransactionRequest` → `BatchPredictResponse` |
+| `GET`  | `/api/v1/health` | `HealthStatus` (model_loaded, redis_connected, kafka_connected, uptime) |
+| `GET`  | `/api/v1/model/info` | `ModelInfoResponse` (n_params, feature_columns, top-k feature importance) |
+| `GET`  | `/api/v1/metrics` | Prometheus exposition (text/plain) |
+| `WS`   | `/ws/alerts` | Pushes `FraudAlert` JSON whenever a transaction crosses `FRAUD_ALERT_THRESHOLD` |
+
+### Latency budget vs measured
+
+| Stage | Plan budget | Measured (CPU, in-process, no Redis, no SHAP) |
+| --- | --- | --- |
+| Cache lookup + tabular + XGBoost | sum < 50 ms | embedded in P95 below |
+| **End-to-end `predict_one` P95** | **<50 ms** | **1.6 ms** ✅ |
+| `predict_batch` (100 rows) | — | 5.2 ms total (≈0.05 ms/row) |
+| Cache-hit `predict_one` P95 | — | 1.2 ms |
+
+### Acceptance criteria (per plan, page 9)
+
+| Criterion | Status |
+| --- | --- |
+| `docker compose up` starts all services | ✅ compose w/ healthchecks for Redis / Kafka / Zookeeper |
+| API returns valid predictions with correct schema | ✅ 15 FastAPI integration tests via TestClient |
+| P95 latency < 50ms | ✅ **1.6 ms** (30× under target) |
+| Kafka consumer processes test transactions | ✅ producer/consumer round-trip + in-memory fallback for tests |
+| WebSocket streams alerts in real time | ✅ end-to-end test: high-score POST → producer → consumer → broadcaster → WS client |
+
+### How the pieces fit together
+
+```
+                      ┌──────────────┐
+   POST /predict ───▶│  FastAPI app  │─── X-Request-ID + Prometheus  ▶ /metrics
+                      └──────┬───────┘
+                             │
+                             ▼
+                      ┌─────────────────┐
+                      │  FraudPredictor │
+                      │ ─────────────── │
+                      │ 1. Embedding    │── miss ──▶ GNN.get_embeddings (fallback)
+                      │    cache (Redis)│
+                      │ 2. Tabular row  │
+                      │ 3. XGBoost      │
+                      │ 4. SHAP (opt.) │
+                      └────────┬────────┘
+                               │
+                  score>=0.7   │
+                               ▼
+                      ┌────────────────┐         ┌─────────────────┐
+                      │ FraudAlert ──▶ │ Kafka ─▶│ Consumer (async)│
+                      │ producer       │ topic   └────────┬────────┘
+                      └────────────────┘ fraud_           │
+                                          alerts          ▼
+                                                   ┌────────────┐
+                                                   │ Broadcaster│ /ws/alerts
+                                                   └─────┬──────┘
+                                                         ▼
+                                                   browser clients
+```
+
 ---
 
 ## Quick start
@@ -166,6 +245,12 @@ make mlflow-ui            # -> http://localhost:5000
 make gnn-eda              # notebooks/03_gnn.ipynb
 make ensemble-eda         # notebooks/04_ensemble.ipynb
 make colab-eda            # notebooks/06_colab_training.ipynb (Colab T4)
+
+# 7. Phase 4: real-time serving
+make serve                # FastAPI on http://127.0.0.1:8000 -- /docs for OpenAPI
+make demo-stream          # replay 200 txns at 5 RPS to /api/v1/predict
+make compose-up           # full Docker stack: Redis + Kafka + MLflow + Prometheus + Grafana + API
+make compose-logs         # tail logs from the API container
 ```
 
 ---
@@ -192,7 +277,9 @@ Meshwatch/
 │   ├── build_graph.py            # Phase 2: heterograph + features
 │   ├── train.py                  # Phase 3: GNN training + MLflow
 │   ├── train_ensemble.py         # Phase 3: GNN+XGBoost ensemble
-│   └── evaluate.py               # Phase 3: PR/ROC/calibration on val or test
+│   ├── evaluate.py               # Phase 3: PR/ROC/calibration on val or test
+│   ├── serve.py                  # Phase 4: FastAPI / Ray Serve launcher
+│   └── demo_stream.py            # Phase 4: replay txns to /api/v1/predict
 ├── src/fraud_detection/
 │   ├── data/                 # download, preprocessing, splits, graph_builder
 │   ├── features/             # temporal, aggregated, graph_features, pipeline
@@ -233,8 +320,8 @@ CI runs the full matrix (Python 3.10 / 3.11 / 3.12) on every push + PR via
 | 1. Foundation & Data Pipeline | `v0.1.0-data-foundation` | ✅ Complete |
 | 2. Graph & Features | `v0.2.0-graph-engine` | ✅ Complete |
 | 3. GNN Model & Training | `v0.3.0-gnn-model` | ✅ Complete |
-| 4. Real-Time Serving | `v0.4.0-serving-pipeline` | 🚧 Up next |
-| 5. Agentic Investigator | `v0.5.0-agent-investigator` | ⏳ Planned |
+| 4. Real-Time Serving | `v0.4.0-serving-pipeline` | ✅ Complete |
+| 5. Agentic Investigator | `v0.5.0-agent-investigator` | 🚧 Up next |
 | 6. React Dashboard | `v0.6.0-dashboard` | ⏳ Planned |
 | 7. MLOps & Monitoring | `v0.7.0-mlops` | ⏳ Planned |
 | 8. Docs, Demo & Polish | `v1.0.0-release` | ⏳ Planned |

--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -1,0 +1,29 @@
+# Prometheus scrape config for the Meshwatch infrastructure (Phase 4).
+#
+# Scrapes the FastAPI app's /api/v1/metrics endpoint and Prometheus's own
+# self-metrics. Phase 7 adds drift / model-degradation alert rules in
+# configs/prometheus_rules.yml.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    service: meshwatch
+    env: local
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: meshwatch-api
+    metrics_path: /api/v1/metrics
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["api:8000"]
+
+  - job_name: meshwatch-api-host
+    metrics_path: /api/v1/metrics
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["host.docker.internal:8000"]

--- a/configs/serve.yaml
+++ b/configs/serve.yaml
@@ -1,0 +1,47 @@
+# Phase 4 serving configuration.
+# Loaded by ``fraud_detection.serving.app`` via env-var overrides; this file
+# documents the canonical defaults + acts as a config-as-code reference.
+
+server:
+  host: 0.0.0.0
+  port: 8000
+  workers: 1                  # plain uvicorn worker count (ignored by Ray Serve)
+  log_level: info
+  access_log_via_middleware: true
+
+predictor:
+  ensemble_dir: data/models/ensemble
+  alert_threshold: 0.7        # writes to Kafka 'fraud_alerts' at-or-above
+  enable_shap: true
+  shap_max_display: 5
+
+cache:
+  redis_url: null             # null -> in-memory fallback
+  ttl_seconds: 3600
+  embedding_dim: 64
+  warm_up_at_startup: false   # if true, walk known cards and seed Redis
+
+streaming:
+  bootstrap_servers: null     # null -> in-memory fallback (tests + local laptop)
+  fraud_topic: fraud_alerts
+  consumer_group: meshwatch-fanout
+  poll_timeout_seconds: 1.0
+
+ray_serve:
+  enabled: false              # opt-in via scripts/serve.py --ray
+  num_replicas: 1
+  num_cpus_per_replica: 0.5
+  max_ongoing_requests: 64
+
+prometheus:
+  enabled: true
+  endpoint: /api/v1/metrics
+
+# Latency budget (ms) -- per the implementation plan, page 9.
+latency_budget_ms:
+  feast_get: 2
+  temporal_features: 5
+  redis_get_embedding: 1
+  xgboost_predict: 2
+  shap_explanation: 10
+  total_p95: 50

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,137 @@
+# ---------------------------------------------------------------------------
+# Meshwatch infrastructure (Phase 4)
+# ---------------------------------------------------------------------------
+# Bring everything up with:
+#     docker compose up -d
+# Tear down with:
+#     docker compose down -v
+# ---------------------------------------------------------------------------
+
+name: meshwatch
+
+services:
+  redis:
+    image: redis:7.4-alpine
+    container_name: meshwatch-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - redis_data:/data
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.6.0
+    container_name: meshwatch-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "2181"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  kafka:
+    image: confluentinc/cp-kafka:7.6.0
+    container_name: meshwatch-kafka
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics --bootstrap-server kafka:9092 --list || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  mlflow:
+    image: ghcr.io/mlflow/mlflow:v2.18.0
+    container_name: meshwatch-mlflow
+    ports:
+      - "5000:5000"
+    command: >
+      mlflow server
+      --host 0.0.0.0
+      --port 5000
+      --backend-store-uri sqlite:///mlflow/mlflow.db
+      --default-artifact-root /mlflow/artifacts
+    volumes:
+      - mlflow_data:/mlflow
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: meshwatch-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./configs/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    container_name: meshwatch-grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.serving
+    container_name: meshwatch-api
+    depends_on:
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    environment:
+      FRAUD_LOG_LEVEL: INFO
+      FRAUD_ENSEMBLE_DIR: /app/data/models/ensemble
+      REDIS_URL: redis://redis:6379/0
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_FRAUD_TOPIC: fraud_alerts
+      FRAUD_ALERT_THRESHOLD: "0.7"
+      FRAUD_ENABLE_SHAP: "true"
+    volumes:
+      - ./data:/app/data:ro
+      - ./configs:/app/configs:ro
+    restart: unless-stopped
+
+volumes:
+  redis_data:
+  mlflow_data:
+  prometheus_data:
+  grafana_data:

--- a/scripts/demo_stream.py
+++ b/scripts/demo_stream.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+"""Replay transactions to the fraud-detection API for demo / load testing.
+
+Reads rows from ``data/graphs/features.parquet`` (or any IEEE-CIS-shaped
+parquet) and POSTs them to ``/api/v1/predict`` at a configurable rate.
+Useful for:
+
+* Driving a populated dashboard during a demo.
+* Producing latency stats (P50/P95/P99) under realistic load.
+* Stress-testing the alert pipeline.
+
+Examples::
+
+    # Send 200 transactions at 5 RPS to localhost:
+    python scripts/demo_stream.py --n 200 --rps 5
+
+    # Stress test: 2000 txns, 50 RPS, batch endpoint:
+    python scripts/demo_stream.py --n 2000 --rps 50 --batch 50
+
+    # Hit a remote API:
+    python scripts/demo_stream.py --url http://meshwatch.dev/api/v1/predict
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+import click  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from fraud_detection.utils.config import load_config  # noqa: E402
+from fraud_detection.utils.logging import configure_logging, get_logger  # noqa: E402
+
+
+def _row_to_request(row: pd.Series) -> dict:
+    """Map a parquet row into a TransactionRequest payload."""
+    out: dict = {
+        "transaction_id": int(row.get("TransactionID", 0)),
+        "transaction_dt": int(row.get("TransactionDT", 0)),
+        "transaction_amt": float(row.get("TransactionAmt", 0.0)),
+        "product_cd": "W",
+    }
+    # Optional numeric fields
+    for col, dest in [
+        ("card1", "card1"),
+        ("card2", "card2"),
+        ("card3", "card3"),
+        ("card5", "card5"),
+        ("addr1", "addr1"),
+        ("addr2", "addr2"),
+        ("dist1", "dist1"),
+        ("dist2", "dist2"),
+    ]:
+        v = row.get(col)
+        if v is not None and not (isinstance(v, float) and np.isnan(v)):
+            out[dest] = float(v) if dest != "card1" else int(v)
+    return out
+
+
+@click.command()
+@click.option(
+    "--url",
+    default="http://127.0.0.1:8000/api/v1/predict",
+    show_default=True,
+    help="Predict endpoint (single tx). Use --batch to switch to batch endpoint.",
+)
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="Parquet to draw rows from (default: data/graphs/features.parquet).",
+)
+@click.option("--n", default=100, show_default=True, type=int, help="Total tx to send.")
+@click.option("--rps", default=10.0, show_default=True, type=float, help="Target RPS.")
+@click.option(
+    "--batch",
+    default=0,
+    show_default=True,
+    type=int,
+    help="If >0, switch to /predict/batch with this batch size.",
+)
+@click.option("--seed", default=42, show_default=True, type=int)
+@click.option(
+    "--summary-only",
+    is_flag=True,
+    help="Suppress per-request logging; only print latency summary.",
+)
+def main(
+    url: str,
+    input_path: str | None,
+    n: int,
+    rps: float,
+    batch: int,
+    seed: int,
+    summary_only: bool,
+) -> None:
+    cfg = load_config()
+    configure_logging(level=cfg.logging.level, json=cfg.logging.use_json)
+    log = get_logger("demo_stream")
+
+    import requests
+
+    parquet = Path(input_path) if input_path else cfg.paths.data_graphs / "features.parquet"
+    if not parquet.exists():
+        msg = f"Input parquet not found: {parquet}. Run `make build-graph` first."
+        raise FileNotFoundError(msg)
+
+    df = pd.read_parquet(parquet)
+    rng = np.random.default_rng(seed)
+    if len(df) > n:
+        df = df.iloc[rng.choice(len(df), size=n, replace=False)]
+    df = df.reset_index(drop=True)
+
+    if batch > 0:
+        url = url.rstrip("/").replace("/api/v1/predict", "/api/v1/predict/batch")
+        log.info("demo_stream_start_batch", url=url, n=len(df), batch=batch, rps=rps)
+    else:
+        log.info("demo_stream_start_single", url=url, n=len(df), rps=rps)
+
+    delay = 1.0 / rps if rps > 0 else 0.0
+    latencies_ms: list[float] = []
+    n_alerts = 0
+    n_errors = 0
+
+    sent = 0
+    while sent < len(df):
+        chunk = df.iloc[sent : sent + (batch or 1)]
+        sent += len(chunk)
+        payload: dict
+        if batch > 0:
+            payload = {"transactions": [_row_to_request(r) for _, r in chunk.iterrows()]}
+        else:
+            payload = _row_to_request(chunk.iloc[0])
+
+        t0 = time.perf_counter()
+        try:
+            r = requests.post(url, json=payload, timeout=10.0)
+            elapsed = (time.perf_counter() - t0) * 1000
+            latencies_ms.append(elapsed)
+            if r.status_code != 200:
+                n_errors += 1
+                if not summary_only:
+                    log.warning("predict_error", status=r.status_code, body=r.text[:200])
+            else:
+                body = r.json()
+                if batch > 0:
+                    n_alerts += int(body.get("n_alerts", 0))
+                    if not summary_only:
+                        log.info(
+                            "batch_response",
+                            n_processed=body.get("n_processed"),
+                            n_alerts=body.get("n_alerts"),
+                            elapsed_ms=round(elapsed, 2),
+                        )
+                else:
+                    if body.get("is_fraud_predicted"):
+                        n_alerts += 1
+                    if not summary_only:
+                        log.info(
+                            "predict_response",
+                            tx=body.get("transaction_id"),
+                            score=round(body.get("fraud_score", 0.0), 4),
+                            risk=body.get("risk_level"),
+                            elapsed_ms=round(elapsed, 2),
+                        )
+        except Exception as exc:
+            n_errors += 1
+            if not summary_only:
+                log.warning("predict_request_failed", error=str(exc))
+
+        if delay > 0 and sent < len(df):
+            time.sleep(delay)
+
+    if latencies_ms:
+        arr = np.array(latencies_ms)
+        log.info(
+            "demo_stream_complete",
+            n_sent=len(df),
+            n_alerts=n_alerts,
+            n_errors=n_errors,
+            p50_ms=round(float(np.percentile(arr, 50)), 2),
+            p95_ms=round(float(np.percentile(arr, 95)), 2),
+            p99_ms=round(float(np.percentile(arr, 99)), 2),
+            mean_ms=round(float(arr.mean()), 2),
+            max_ms=round(float(arr.max()), 2),
+        )
+    else:
+        log.warning("demo_stream_complete_no_responses")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+"""Launch the Meshwatch fraud-detection API.
+
+Plain FastAPI / uvicorn (default)::
+
+    python scripts/serve.py
+    python scripts/serve.py --host 0.0.0.0 --port 8000 --reload
+
+Ray Serve (multi-replica, opt-in)::
+
+    python scripts/serve.py --ray --num-replicas 2
+
+Common env vars (all optional -- the app falls back gracefully):
+    FRAUD_ENSEMBLE_DIR        path to data/models/ensemble
+    REDIS_URL                 e.g. redis://localhost:6379/0
+    KAFKA_BOOTSTRAP_SERVERS   e.g. localhost:9092
+    KAFKA_FRAUD_TOPIC         default "fraud_alerts"
+    FRAUD_ALERT_THRESHOLD     default 0.7
+    FRAUD_ENABLE_SHAP         "true" / "false" (default true)
+    FRAUD_LOG_LEVEL           default "INFO"
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+import click  # noqa: E402
+
+from fraud_detection.utils.config import load_config  # noqa: E402
+from fraud_detection.utils.logging import configure_logging, get_logger  # noqa: E402
+
+
+@click.command()
+@click.option("--host", default="127.0.0.1", show_default=True)
+@click.option("--port", default=8000, show_default=True, type=int)
+@click.option("--reload", is_flag=True, help="Auto-reload on code changes (dev only)")
+@click.option(
+    "--workers",
+    default=1,
+    show_default=True,
+    type=int,
+    help="Uvicorn worker count (ignored with --ray or --reload)",
+)
+@click.option("--ray", is_flag=True, help="Run via Ray Serve instead of plain uvicorn")
+@click.option("--num-replicas", default=1, show_default=True, type=int)
+@click.option("--log-level", default="info", show_default=True)
+def main(
+    host: str,
+    port: int,
+    reload: bool,
+    workers: int,
+    ray: bool,
+    num_replicas: int,
+    log_level: str,
+) -> None:
+    cfg = load_config()
+    configure_logging(level=cfg.logging.level, json=cfg.logging.use_json)
+    log = get_logger("serve")
+
+    if ray:
+        log.info(
+            "starting_ray_serve",
+            host=host,
+            port=port,
+            num_replicas=num_replicas,
+        )
+        from fraud_detection.serving.ray_deployment import run_deployment
+
+        run_deployment(num_replicas=num_replicas, host=host, port=port, blocking=True)
+        return
+
+    log.info("starting_uvicorn", host=host, port=port, workers=workers, reload=reload)
+    import uvicorn
+
+    uvicorn.run(
+        "fraud_detection.serving.app:app",
+        host=host,
+        port=port,
+        reload=reload,
+        workers=workers if not reload else 1,
+        log_level=log_level,
+        access_log=False,  # we have our own structured access log
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fraud_detection/serving/__init__.py
+++ b/src/fraud_detection/serving/__init__.py
@@ -1,1 +1,56 @@
-"""FastAPI + Ray Serve serving stack (Phase 4)."""
+"""FastAPI + Ray Serve serving stack (Phase 4).
+
+Public surface:
+
+* :class:`FraudPredictor` -- core scoring path (Feast + cache + ensemble + SHAP).
+* :class:`EmbeddingCache` -- Redis-backed cache with in-memory fallback.
+* :class:`AlertBroadcaster` -- WebSocket fan-out for ``/ws/alerts``.
+* :class:`RequestTimingMiddleware` -- structured-log access logs + Prometheus metrics.
+* :func:`create_app` -- FastAPI factory.
+* :func:`build_deployment` -- optional Ray Serve wrapper.
+* Pydantic schemas for request/response/streaming.
+"""
+
+from fraud_detection.serving.app import (
+    AlertBroadcaster,
+    AppState,
+    app,
+    create_app,
+)
+from fraud_detection.serving.middleware import RequestTimingMiddleware, metrics
+from fraud_detection.serving.predictor import FraudPredictor, load_predictor
+from fraud_detection.serving.redis_cache import EmbeddingCache
+from fraud_detection.serving.schemas import (
+    ALERT_THRESHOLD,
+    BatchPredictRequest,
+    BatchPredictResponse,
+    FeatureContribution,
+    FraudAlert,
+    FraudPrediction,
+    HealthStatus,
+    ModelInfoResponse,
+    TransactionRequest,
+    risk_level,
+)
+
+__all__ = [
+    "ALERT_THRESHOLD",
+    "AlertBroadcaster",
+    "AppState",
+    "BatchPredictRequest",
+    "BatchPredictResponse",
+    "EmbeddingCache",
+    "FeatureContribution",
+    "FraudAlert",
+    "FraudPrediction",
+    "FraudPredictor",
+    "HealthStatus",
+    "ModelInfoResponse",
+    "RequestTimingMiddleware",
+    "TransactionRequest",
+    "app",
+    "create_app",
+    "load_predictor",
+    "metrics",
+    "risk_level",
+]

--- a/src/fraud_detection/serving/app.py
+++ b/src/fraud_detection/serving/app.py
@@ -1,0 +1,367 @@
+"""FastAPI app for the fraud-detection serving pipeline.
+
+Endpoints (matching Phase 4 of the implementation plan, page 9):
+
+* ``POST /api/v1/predict``        single transaction
+* ``POST /api/v1/predict/batch``  up to 100 transactions
+* ``GET  /api/v1/health``         liveness + dependency status
+* ``GET  /api/v1/model/info``     model version + feature schema
+* ``GET  /api/v1/metrics``        Prometheus exposition
+* ``WS   /ws/alerts``             real-time fraud-alert stream
+
+Lifespan responsibilities:
+
+* Construct :class:`FraudPredictor` from the trained ensemble bundle.
+* Connect Redis (or fall back to in-memory).
+* Connect Kafka producer + start the alert-fan-out consumer.
+* Wire a per-app :class:`AlertBroadcaster` for the WebSocket endpoint.
+
+The whole stack is built so that *any* dependency missing degrades to a
+locally-runnable mode -- great for tests, demos, and CPU-only laptops.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import time
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from fastapi import Body, FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse, Response
+
+from fraud_detection.serving.middleware import RequestTimingMiddleware, metrics
+from fraud_detection.serving.predictor import FraudPredictor, load_predictor
+from fraud_detection.serving.schemas import (
+    ALERT_THRESHOLD,
+    BatchPredictRequest,
+    BatchPredictResponse,
+    FraudAlert,
+    FraudPrediction,
+    HealthStatus,
+    ModelInfoResponse,
+    TransactionRequest,
+)
+from fraud_detection.streaming.kafka_consumer import FraudAlertConsumer
+from fraud_detection.streaming.kafka_producer import FraudAlertProducer
+from fraud_detection.utils.logging import configure_logging, get_logger
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket fan-out
+# ---------------------------------------------------------------------------
+
+
+class AlertBroadcaster:
+    """Maintains a set of connected WebSocket clients + pushes alerts to all."""
+
+    def __init__(self) -> None:
+        self._clients: set[WebSocket] = set()
+        self._lock = asyncio.Lock()
+
+    async def connect(self, ws: WebSocket) -> None:
+        await ws.accept()
+        async with self._lock:
+            self._clients.add(ws)
+        log.info("ws_client_connected", n_clients=len(self._clients))
+
+    async def disconnect(self, ws: WebSocket) -> None:
+        async with self._lock:
+            self._clients.discard(ws)
+        log.info("ws_client_disconnected", n_clients=len(self._clients))
+
+    async def broadcast(self, alert: FraudAlert) -> None:
+        # Send synchronously to each socket; drop on failure.
+        if not self._clients:
+            return
+        payload = alert.model_dump(mode="json")
+        async with self._lock:
+            stale: list[WebSocket] = []
+            for ws in self._clients:
+                try:
+                    await ws.send_json(payload)
+                except Exception as exc:
+                    log.warning("ws_send_failed", error=str(exc))
+                    stale.append(ws)
+            for ws in stale:
+                self._clients.discard(ws)
+        metrics.alerts_total.labels("websocket").inc()
+
+    @property
+    def n_clients(self) -> int:
+        return len(self._clients)
+
+
+# ---------------------------------------------------------------------------
+# App state container
+# ---------------------------------------------------------------------------
+
+
+class AppState:
+    predictor: FraudPredictor | None
+    producer: FraudAlertProducer | None
+    consumer: FraudAlertConsumer | None
+    broadcaster: AlertBroadcaster
+    started_at: float
+    settings: dict[str, Any]
+
+    def __init__(self) -> None:
+        self.predictor = None
+        self.producer = None
+        self.consumer = None
+        self.broadcaster = AlertBroadcaster()
+        self.started_at = time.time()
+        self.settings = {}
+
+
+# ---------------------------------------------------------------------------
+# Lifespan
+# ---------------------------------------------------------------------------
+
+
+def _resolve_settings() -> dict[str, Any]:
+    return {
+        "ensemble_dir": os.environ.get("FRAUD_ENSEMBLE_DIR", "data/models/ensemble"),
+        "redis_url": os.environ.get("REDIS_URL"),
+        "kafka_bootstrap": os.environ.get("KAFKA_BOOTSTRAP_SERVERS"),
+        "kafka_topic": os.environ.get("KAFKA_FRAUD_TOPIC", "fraud_alerts"),
+        "alert_threshold": float(os.environ.get("FRAUD_ALERT_THRESHOLD", str(ALERT_THRESHOLD))),
+        "enable_shap": os.environ.get("FRAUD_ENABLE_SHAP", "true").lower() != "false",
+    }
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    configure_logging(level=os.environ.get("FRAUD_LOG_LEVEL", "INFO"))
+    state = AppState()
+    state.settings = _resolve_settings()
+    log.info("serving_startup", **state.settings)
+
+    # Predictor (best-effort -- the API stays up even if the model is missing,
+    # so /health can still report the issue).
+    try:
+        ensemble_dir = Path(state.settings["ensemble_dir"])
+        if ensemble_dir.exists() and (ensemble_dir / "artifacts.pkl").exists():
+            state.predictor = load_predictor(
+                ensemble_dir=ensemble_dir,
+                redis_url=state.settings["redis_url"],
+                enable_shap=state.settings["enable_shap"],
+                threshold=state.settings["alert_threshold"],
+            )
+            log.info("predictor_loaded", info=state.predictor.info())
+        else:
+            log.warning(
+                "predictor_unavailable_no_artifacts",
+                ensemble_dir=str(ensemble_dir),
+            )
+    except Exception as exc:
+        log.exception("predictor_load_failed", error=str(exc))
+
+    # Kafka producer (degrades to in-memory).
+    state.producer = FraudAlertProducer(
+        bootstrap_servers=state.settings["kafka_bootstrap"],
+        topic=state.settings["kafka_topic"],
+    )
+    state.producer.connect()
+
+    # Consumer task: drain Kafka (or in-mem) -> fan out to WebSockets.
+    state.consumer = FraudAlertConsumer(
+        bootstrap_servers=state.settings["kafka_bootstrap"],
+        topic=state.settings["kafka_topic"],
+        group_id="meshwatch-fanout",
+    )
+    state.consumer.connect()
+
+    async def _fanout(alert: FraudAlert) -> None:
+        await state.broadcaster.broadcast(alert)
+
+    consumer_task = asyncio.create_task(state.consumer.consume_async(_fanout))
+
+    app.state.fraud_app = state
+    try:
+        yield
+    finally:
+        log.info("serving_shutdown")
+        consumer_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await consumer_task
+        if state.consumer:
+            state.consumer.stop()
+        if state.producer:
+            state.producer.close()
+
+
+# ---------------------------------------------------------------------------
+# App + middleware
+# ---------------------------------------------------------------------------
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="Meshwatch Fraud Detection",
+        version="v0.4.0-serving-pipeline",
+        description="Real-time GNN+XGBoost fraud-detection inference API.",
+        lifespan=lifespan,
+    )
+    app.add_middleware(RequestTimingMiddleware)
+    _register_routes(app)
+    return app
+
+
+def _register_routes(app: FastAPI) -> None:
+    """Attach every endpoint as a closure over ``request.app.state``.
+
+    Done via a function so :func:`create_app` is the single source of truth
+    and tests can build an app without a model on disk.
+    """
+
+    def _state(request: Request) -> AppState:
+        return request.app.state.fraud_app
+
+    # ---- Predict (single) ---------------------------------------------------
+
+    @app.post("/api/v1/predict", response_model=FraudPrediction, tags=["predict"])
+    async def predict(
+        request: Request,
+        payload: TransactionRequest = Body(...),  # noqa: B008 -- FastAPI idiom
+    ) -> FraudPrediction:
+        s = _state(request)
+        if s.predictor is None:
+            raise HTTPException(status_code=503, detail="Model not loaded")
+        result = s.predictor.predict_one(payload)
+        metrics.predictions_total.labels(result.risk_level).inc()
+        if result.fraud_score >= s.predictor.threshold and s.producer is not None:
+            alert = _to_alert(result, payload)
+            s.producer.publish(alert)
+            if not s.producer.is_kafka and s.consumer is not None:
+                s.consumer.push_in_memory(alert)
+            metrics.alerts_total.labels("kafka").inc()
+        return result
+
+    # ---- Predict (batch) ----------------------------------------------------
+
+    @app.post("/api/v1/predict/batch", response_model=BatchPredictResponse, tags=["predict"])
+    async def predict_batch(
+        request: Request,
+        payload: BatchPredictRequest = Body(...),  # noqa: B008 -- FastAPI idiom
+    ) -> BatchPredictResponse:
+        s = _state(request)
+        if s.predictor is None:
+            raise HTTPException(status_code=503, detail="Model not loaded")
+        t0 = time.perf_counter()
+        results = s.predictor.predict_batch(payload.transactions)
+        elapsed = (time.perf_counter() - t0) * 1000
+        n_alerts = 0
+        for r, tx in zip(results, payload.transactions, strict=True):
+            metrics.predictions_total.labels(r.risk_level).inc()
+            if r.fraud_score >= s.predictor.threshold and s.producer is not None:
+                alert = _to_alert(r, tx)
+                s.producer.publish(alert)
+                if not s.producer.is_kafka and s.consumer is not None:
+                    s.consumer.push_in_memory(alert)
+                metrics.alerts_total.labels("kafka").inc()
+                n_alerts += 1
+        return BatchPredictResponse(
+            predictions=results,
+            n_processed=len(results),
+            n_alerts=n_alerts,
+            elapsed_ms=elapsed,
+        )
+
+    # ---- Health -------------------------------------------------------------
+
+    @app.get("/api/v1/health", response_model=HealthStatus, tags=["system"])
+    async def health(request: Request) -> HealthStatus:
+        s = _state(request)
+        return HealthStatus(
+            status="ok" if s.predictor is not None else "degraded",
+            model_loaded=s.predictor is not None,
+            redis_connected=(s.predictor is not None and s.predictor.cache.is_redis()),
+            kafka_connected=bool(s.producer and s.producer.is_kafka),
+            ray_serve_active=os.environ.get("FRAUD_RAY_SERVE", "false") == "true",
+            uptime_seconds=time.time() - s.started_at,
+        )
+
+    # ---- Model info ---------------------------------------------------------
+
+    @app.get("/api/v1/model/info", response_model=ModelInfoResponse, tags=["system"])
+    async def model_info(request: Request) -> ModelInfoResponse:
+        s = _state(request)
+        if s.predictor is None:
+            raise HTTPException(status_code=503, detail="Model not loaded")
+
+        ensemble = s.predictor.ensemble
+        gnn = ensemble.gnn
+        try:
+            importance = ensemble.xgb.feature_importance(kind="gain")
+            top = dict(sorted(importance.items(), key=lambda kv: kv[1], reverse=True)[:25])
+        except Exception:
+            top = {}
+
+        return ModelInfoResponse(
+            model_version=s.predictor.model_version,
+            n_parameters=gnn.n_parameters(),
+            embedding_dim=gnn.embedding_dim,
+            n_features=len(s.predictor.feature_columns),
+            feature_columns=s.predictor.feature_columns,
+            edge_types=[",".join(e) for e in gnn.edge_types],
+            node_types=list(gnn.node_types),
+            train_metrics={},  # Phase 7 will populate from MLflow
+            feature_importance_top_k=top,
+        )
+
+    # ---- Prometheus metrics -------------------------------------------------
+
+    @app.get("/api/v1/metrics", tags=["system"])
+    async def metrics_endpoint() -> Response:
+        return Response(content=metrics.render(), media_type=metrics.content_type)
+
+    # ---- WebSocket alert stream --------------------------------------------
+
+    @app.websocket("/ws/alerts")
+    async def ws_alerts(ws: WebSocket) -> None:
+        s: AppState = ws.app.state.fraud_app
+        await s.broadcaster.connect(ws)
+        try:
+            while True:
+                # Keep the connection alive; real broadcasts come from the
+                # consumer task. We just await any client message (ping)
+                # and discard.
+                await ws.receive_text()
+        except WebSocketDisconnect:
+            await s.broadcaster.disconnect(ws)
+        except Exception as exc:
+            log.warning("ws_unexpected_error", error=str(exc))
+            await s.broadcaster.disconnect(ws)
+
+    # ---- Root convenience ---------------------------------------------------
+
+    @app.get("/", include_in_schema=False)
+    async def root() -> JSONResponse:
+        return JSONResponse({"service": "meshwatch", "version": app.version, "docs": "/docs"})
+
+
+def _to_alert(result: FraudPrediction, request: TransactionRequest) -> FraudAlert:
+    risk = result.risk_level
+    if risk == "LOW":
+        risk = "MEDIUM"
+    return FraudAlert(
+        transaction_id=result.transaction_id,
+        fraud_score=result.fraud_score,
+        risk_level=risk,  # type: ignore[arg-type]
+        transaction_amt=request.transaction_amt,
+        card_id=request.card1,
+        top_features=result.top_features,
+    )
+
+
+# Module-level app for ``uvicorn fraud_detection.serving.app:app``.
+app = create_app()
+
+
+__all__ = ["AlertBroadcaster", "AppState", "app", "create_app", "lifespan"]

--- a/src/fraud_detection/serving/middleware.py
+++ b/src/fraud_detection/serving/middleware.py
@@ -1,0 +1,180 @@
+"""FastAPI middleware: request timing, structured-logging access logs, Prometheus metrics.
+
+Designed so the metrics module is importable without breaking the app
+when ``prometheus-client`` is missing (Phase 7 makes it mandatory; for
+Phase 4 we keep it optional).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Prometheus integration -- optional
+# ---------------------------------------------------------------------------
+
+
+class _MetricsRegistry:
+    """Thin wrapper around prometheus_client that no-ops when the lib is missing.
+
+    We expose ``request_count``, ``request_latency``, ``in_flight``,
+    ``predictions_total``, ``alerts_total`` as instance attributes whose
+    ``.labels(...).inc()`` etc. methods are either real Prometheus
+    objects or harmless stubs.
+    """
+
+    def __init__(self) -> None:
+        try:
+            from prometheus_client import (
+                CONTENT_TYPE_LATEST,
+                CollectorRegistry,
+                Counter,
+                Gauge,
+                Histogram,
+                generate_latest,
+            )
+
+            self._enabled = True
+            self.registry = CollectorRegistry()
+            self.request_count = Counter(
+                "meshwatch_http_requests_total",
+                "HTTP requests",
+                ["method", "path", "status"],
+                registry=self.registry,
+            )
+            self.request_latency = Histogram(
+                "meshwatch_http_request_latency_seconds",
+                "HTTP request latency",
+                ["method", "path"],
+                buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+                registry=self.registry,
+            )
+            self.in_flight = Gauge(
+                "meshwatch_http_in_flight_requests",
+                "In-flight HTTP requests",
+                registry=self.registry,
+            )
+            self.predictions_total = Counter(
+                "meshwatch_predictions_total",
+                "Predictions served",
+                ["risk_level"],
+                registry=self.registry,
+            )
+            self.alerts_total = Counter(
+                "meshwatch_alerts_published_total",
+                "Fraud alerts published to Kafka / WebSocket",
+                ["channel"],
+                registry=self.registry,
+            )
+            self._generate_latest = generate_latest
+            self.content_type = CONTENT_TYPE_LATEST
+        except ImportError:
+            self._enabled = False
+            self._generate_latest = None
+            self.content_type = "text/plain; version=0.0.4; charset=utf-8"
+            self.request_count = _NoopMetric()
+            self.request_latency = _NoopMetric()
+            self.in_flight = _NoopMetric()
+            self.predictions_total = _NoopMetric()
+            self.alerts_total = _NoopMetric()
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def render(self) -> bytes:
+        if self._enabled and self._generate_latest is not None:
+            return self._generate_latest(self.registry)
+        return b"# prometheus_client not installed\n"
+
+
+class _NoopMetric:
+    """Stand-in for Prometheus metrics when the library isn't installed."""
+
+    def labels(self, *args: Any, **kwargs: Any) -> _NoopMetric:
+        return self
+
+    def inc(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def dec(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def observe(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def set(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+# Module-level singleton -- the FastAPI app reaches into this for
+# /api/v1/metrics rendering.
+metrics = _MetricsRegistry()
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+
+class RequestTimingMiddleware(BaseHTTPMiddleware):
+    """Add ``X-Request-ID`` + ``X-Response-Time-MS`` headers and log every request."""
+
+    HEADER_REQUEST_ID = "x-request-id"
+    HEADER_RESPONSE_TIME = "x-response-time-ms"
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        request_id = request.headers.get(self.HEADER_REQUEST_ID) or uuid.uuid4().hex
+        start = time.perf_counter()
+        path_template = request.url.path
+        method = request.method
+
+        metrics.in_flight.inc()
+        try:
+            response = await call_next(request)
+        except Exception as exc:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            log.exception(
+                "http_request_failed",
+                request_id=request_id,
+                method=method,
+                path=path_template,
+                error=str(exc),
+                elapsed_ms=elapsed_ms,
+            )
+            metrics.request_count.labels(method, path_template, "500").inc()
+            metrics.request_latency.labels(method, path_template).observe(elapsed_ms / 1000)
+            raise
+        finally:
+            metrics.in_flight.dec()
+
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        response.headers[self.HEADER_REQUEST_ID] = request_id
+        response.headers[self.HEADER_RESPONSE_TIME] = f"{elapsed_ms:.2f}"
+
+        metrics.request_count.labels(method, path_template, str(response.status_code)).inc()
+        metrics.request_latency.labels(method, path_template).observe(elapsed_ms / 1000)
+
+        log.info(
+            "http_request_complete",
+            request_id=request_id,
+            method=method,
+            path=path_template,
+            status=response.status_code,
+            elapsed_ms=round(elapsed_ms, 3),
+        )
+        return response
+
+
+__all__ = ["RequestTimingMiddleware", "metrics"]

--- a/src/fraud_detection/serving/predictor.py
+++ b/src/fraud_detection/serving/predictor.py
@@ -1,0 +1,371 @@
+"""End-to-end fraud-prediction service.
+
+This is the production hot path -- everything between an inbound HTTP
+request and the JSON :class:`FraudPrediction` response. The Phase 4 plan
+allocates the latency budget like this::
+
+    [1] Feast get_online_features(card_id)              ~2 ms
+    [2] Compute real-time temporal features            ~5 ms
+    [3] Get cached GNN embedding from Redis            ~1 ms
+    [4] XGBoost predict_proba                          ~2 ms
+    [5] SHAP explanation                              ~10 ms
+    -----------------------------------------------------------
+    target P95                                        <50 ms
+
+The :class:`FraudPredictor` is built around the :class:`FraudEnsemble`
+artifact bundle from Phase 3. It assembles the input row from the request
++ pre-warmed graph context, slots in the cached card embedding, and falls
+back gracefully when any of (Redis, SHAP, real graph) aren't available.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from fraud_detection.models import FraudEnsemble
+from fraud_detection.serving.redis_cache import EmbeddingCache
+from fraud_detection.serving.schemas import (
+    ALERT_THRESHOLD,
+    FeatureContribution,
+    FraudPrediction,
+    TransactionRequest,
+    risk_level,
+)
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass for hot-path use (no Pydantic overhead)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PredictionResult:
+    proba: float
+    embedding_used_cache: bool
+    contributions: list[FeatureContribution]
+    timings: dict[str, float] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# FraudPredictor
+# ---------------------------------------------------------------------------
+
+
+class FraudPredictor:
+    """Stateful predictor that owns the model + caches.
+
+    Build at server startup, then call :meth:`predict_one` per request and
+    :meth:`predict_batch` for bulk endpoints.
+
+    Parameters
+    ----------
+    ensemble
+        A trained :class:`FraudEnsemble` (preloaded GNN + XGBoost).
+    embedding_cache
+        Pre-connected :class:`EmbeddingCache`. The predictor will hit
+        cache for the request's ``card1`` id; on miss it computes the
+        embedding via a full GNN forward and writes it back.
+    feature_columns
+        The exact list of tabular columns expected by the XGBoost stage.
+        Anything missing on a request is filled with 0; anything extra
+        is dropped. This makes the API tolerant to schema drift without
+        losing safety.
+    threshold
+        Score above which we mark ``is_fraud_predicted=True``.
+    enable_shap
+        Toggle the SHAP explainer. Skipped automatically if ``shap``
+        isn't importable.
+    shap_max_display
+        How many top features to include in the response.
+    graph_data
+        Optional reference :class:`HeteroData` (Phase 2). When supplied
+        and a card_id is *known* we route through the GNN branch using
+        the pre-warmed embedding; when not supplied (e.g. unit tests on
+        cold cards) we fall back to a zero embedding.
+    """
+
+    def __init__(
+        self,
+        *,
+        ensemble: FraudEnsemble,
+        embedding_cache: EmbeddingCache,
+        feature_columns: list[str],
+        threshold: float = ALERT_THRESHOLD,
+        enable_shap: bool = True,
+        shap_max_display: int = 5,
+        graph_data: Any | None = None,
+        card_id_to_embedding_index: dict[int | str, int] | None = None,
+        model_version: str = "v0.3.0-gnn-model",
+    ) -> None:
+        self.ensemble = ensemble
+        self.cache = embedding_cache
+        self.feature_columns = list(feature_columns)
+        self.tabular_columns = [c for c in self.feature_columns if not c.startswith("gnn_emb_")]
+        self.embedding_dim = len(self.feature_columns) - len(self.tabular_columns)
+        self.threshold = float(threshold)
+        self.shap_max_display = int(shap_max_display)
+        self.graph_data = graph_data
+        self.card_id_to_embedding_index = card_id_to_embedding_index or {}
+        self.model_version = model_version
+
+        # Lazy SHAP setup.
+        self._shap_explainer = None
+        self._enable_shap = enable_shap
+        if enable_shap:
+            self._shap_explainer = self._try_build_shap_explainer()
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+
+    def _try_build_shap_explainer(self) -> Any | None:
+        try:
+            import shap
+
+            booster = self.ensemble.xgb.model
+            explainer = shap.TreeExplainer(booster)
+            log.info("shap_explainer_ready")
+            return explainer
+        except Exception as exc:
+            log.warning("shap_disabled", error=str(exc))
+            return None
+
+    def _resolve_embedding(self, card_id: int | str | None) -> tuple[np.ndarray, bool]:
+        """Return the 64-d embedding to feed the XGBoost stage.
+
+        Strategy (in order):
+        1. If ``card_id`` is in the cache -> use it.
+        2. If ``card_id`` is known to the graph -> compute via a single
+           GNN forward and warm the cache.
+        3. Otherwise -> zero embedding (cold-card fallback).
+        """
+        if card_id is None:
+            return np.zeros(self.embedding_dim, dtype=np.float32), False
+
+        cached = self.cache.get(card_id)
+        if cached is not None and cached.shape[0] == self.embedding_dim:
+            return cached, True
+
+        if (
+            self.graph_data is not None
+            and card_id in self.card_id_to_embedding_index
+            and self.embedding_dim > 0
+        ):
+            idx = self.card_id_to_embedding_index[card_id]
+            with torch.no_grad():
+                emb = self.ensemble.gnn.get_embeddings(self.graph_data)[idx]
+            vec = emb.cpu().numpy().astype(np.float32)
+            self.cache.set(card_id, vec)
+            return vec, False
+
+        return np.zeros(self.embedding_dim, dtype=np.float32), False
+
+    def _build_tabular_row(self, request: TransactionRequest) -> np.ndarray:
+        """Pull request fields + extras into the columns XGBoost was trained on.
+
+        Missing values become 0; unknown fields are silently dropped. We
+        do not run the full Phase 1 preprocessor here -- the request is
+        assumed to be downstream of upstream feature engineering. This
+        keeps the hot path light enough for the 50ms budget.
+        """
+        # Start with a zero-filled vector indexed by the tabular column order.
+        row = np.zeros(len(self.tabular_columns), dtype=np.float32)
+        if not self.tabular_columns:
+            return row
+
+        # Map request fields (and extras) onto the trained columns.
+        # ``model_dump`` (with by_alias) gives us aliased keys like
+        # ``P_emaildomain`` so they line up with IEEE-CIS names.
+        payload = request.model_dump(by_alias=True)
+        # Add common shorthand mappings.
+        payload.setdefault("TransactionAmt", request.transaction_amt)
+        payload.setdefault("TransactionDT", request.transaction_dt)
+        payload.setdefault("ProductCD", request.product_cd)
+        payload.setdefault("isFraud", 0)
+
+        col_to_idx = {c: i for i, c in enumerate(self.tabular_columns)}
+        for k, v in payload.items():
+            idx = col_to_idx.get(k)
+            if idx is None or v is None:
+                continue
+            try:
+                row[idx] = float(v)
+            except (TypeError, ValueError):
+                # Non-numeric field (e.g. raw email string) -- caller should
+                # have integer-encoded these already; we drop them silently.
+                continue
+        return row
+
+    def _shap_contributions(self, x: np.ndarray) -> list[FeatureContribution]:
+        if self._shap_explainer is None:
+            return []
+        try:
+            sv = self._shap_explainer.shap_values(x.reshape(1, -1))
+            sv = np.asarray(sv).reshape(-1)
+        except Exception as exc:
+            log.debug("shap_failed", error=str(exc))
+            return []
+        order = np.argsort(np.abs(sv))[::-1][: self.shap_max_display]
+        return [
+            FeatureContribution(
+                feature=self.feature_columns[i],
+                value=float(x[i]),
+                contribution=float(sv[i]),
+            )
+            for i in order
+        ]
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+
+    def predict_one(self, request: TransactionRequest) -> FraudPrediction:
+        timings: dict[str, float] = {}
+        t_total_start = time.perf_counter()
+
+        # --- 1. Embedding (cache or GNN) ----------------------------------
+        t = time.perf_counter()
+        emb, _used_cache = self._resolve_embedding(request.card1)
+        timings["embedding_ms"] = (time.perf_counter() - t) * 1000
+
+        # --- 2. Tabular row -----------------------------------------------
+        t = time.perf_counter()
+        tab = self._build_tabular_row(request)
+        timings["tabular_ms"] = (time.perf_counter() - t) * 1000
+
+        # --- 3. Stack + XGBoost predict ------------------------------------
+        t = time.perf_counter()
+        x = np.concatenate([emb, tab]).astype(np.float32, copy=False)
+        proba = float(self.ensemble.xgb.predict_proba(x.reshape(1, -1))[0])
+        timings["xgboost_ms"] = (time.perf_counter() - t) * 1000
+
+        # --- 4. SHAP explanation (optional, guarded) -----------------------
+        t = time.perf_counter()
+        contribs = self._shap_contributions(x) if self._enable_shap else []
+        timings["shap_ms"] = (time.perf_counter() - t) * 1000
+
+        timings["total_ms"] = (time.perf_counter() - t_total_start) * 1000
+
+        return FraudPrediction(
+            transaction_id=request.transaction_id,
+            fraud_probability=proba,
+            fraud_score=proba,  # already calibrated by XGBoost
+            risk_level=risk_level(proba),
+            is_fraud_predicted=proba >= self.threshold,
+            threshold=self.threshold,
+            top_features=contribs,
+            latency_ms=timings,
+            model_version=self.model_version,
+        )
+
+    def predict_batch(self, requests: Iterable[TransactionRequest]) -> list[FraudPrediction]:
+        # Batch the XGBoost path to amortise overhead. Embedding lookup
+        # remains per-row because each card may live in a different
+        # cache shard, but XGBoost benefits from a (B, F) call.
+        rows: list[np.ndarray] = []
+        emb_used: list[bool] = []
+        emb_timings: list[float] = []
+        tab_timings: list[float] = []
+        ids: list[int | str] = []
+        thresholds: list[float] = []
+        request_list = list(requests)
+
+        for r in request_list:
+            t0 = time.perf_counter()
+            emb, used = self._resolve_embedding(r.card1)
+            emb_timings.append((time.perf_counter() - t0) * 1000)
+            t1 = time.perf_counter()
+            tab = self._build_tabular_row(r)
+            tab_timings.append((time.perf_counter() - t1) * 1000)
+            rows.append(np.concatenate([emb, tab]))
+            emb_used.append(used)
+            ids.append(r.transaction_id)
+            thresholds.append(self.threshold)
+
+        if not rows:
+            return []
+
+        X = np.vstack(rows).astype(np.float32, copy=False)
+        t_x = time.perf_counter()
+        probas = self.ensemble.xgb.predict_proba(X)
+        xgb_ms = (time.perf_counter() - t_x) * 1000
+
+        out: list[FraudPrediction] = []
+        for i, (r, p) in enumerate(zip(request_list, probas, strict=True)):
+            t_s = time.perf_counter()
+            contribs = self._shap_contributions(X[i]) if self._enable_shap else []
+            shap_ms = (time.perf_counter() - t_s) * 1000
+            out.append(
+                FraudPrediction(
+                    transaction_id=r.transaction_id,
+                    fraud_probability=float(p),
+                    fraud_score=float(p),
+                    risk_level=risk_level(float(p)),
+                    is_fraud_predicted=float(p) >= self.threshold,
+                    threshold=self.threshold,
+                    top_features=contribs,
+                    latency_ms={
+                        "embedding_ms": emb_timings[i],
+                        "tabular_ms": tab_timings[i],
+                        "xgboost_ms": xgb_ms / max(len(rows), 1),
+                        "shap_ms": shap_ms,
+                    },
+                    model_version=self.model_version,
+                )
+            )
+        return out
+
+    # ------------------------------------------------------------------
+    # introspection
+    # ------------------------------------------------------------------
+
+    def info(self) -> dict[str, Any]:
+        return {
+            "model_version": self.model_version,
+            "n_features": len(self.feature_columns),
+            "embedding_dim": self.embedding_dim,
+            "shap_enabled": self._shap_explainer is not None,
+            "graph_attached": self.graph_data is not None,
+            "cache_stats": self.cache.stats(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Loader: build a FraudPredictor from disk
+# ---------------------------------------------------------------------------
+
+
+def load_predictor(
+    *,
+    ensemble_dir: str | Path = "data/models/ensemble",
+    redis_url: str | None = None,
+    enable_shap: bool = True,
+    threshold: float = ALERT_THRESHOLD,
+) -> FraudPredictor:
+    """Build a predictor from a trained ensemble directory.
+
+    Used by ``serving/app.py`` at startup.
+    """
+    ensemble = FraudEnsemble.load(ensemble_dir)
+    cache = EmbeddingCache(url=redis_url)
+    cache.connect()
+    return FraudPredictor(
+        ensemble=ensemble,
+        embedding_cache=cache,
+        feature_columns=ensemble.feature_columns,
+        threshold=threshold,
+        enable_shap=enable_shap,
+    )
+
+
+__all__ = ["FraudPredictor", "load_predictor"]

--- a/src/fraud_detection/serving/ray_deployment.py
+++ b/src/fraud_detection/serving/ray_deployment.py
@@ -1,0 +1,137 @@
+"""Optional Ray Serve deployment of the fraud-prediction service.
+
+Use cases:
+
+* Horizontal scaling -- spin up multiple replicas of the predictor
+  behind one HTTP endpoint.
+* Resource isolation -- pin GPU vs CPU replicas separately.
+* Production-grade autoscaling and rolling deploys.
+
+Phase 4's plan calls for FastAPI + Ray Serve at <50ms P95. For local dev
+on a 16GB Ryzen Ray adds more overhead than benefit, so we keep it
+**opt-in** via a CLI flag. The plain FastAPI app in :mod:`app` is the
+default.
+
+Run with::
+
+    python scripts/serve.py --ray --num-replicas 2
+
+or programmatically::
+
+    deployment = build_deployment()
+    serve.run(deployment, name="fraud_detection")
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fraud_detection.serving.app import app as fastapi_app
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+def _check_ray_available() -> tuple[Any, Any] | None:
+    """Lazy-import ray + ray.serve, returning ``None`` if unavailable."""
+    try:
+        import ray
+        from ray import serve
+
+        return ray, serve
+    except ImportError as exc:
+        log.warning("ray_serve_unavailable", error=str(exc))
+        return None
+
+
+def build_deployment(
+    *,
+    num_replicas: int = 1,
+    num_cpus_per_replica: float = 0.5,
+    max_ongoing_requests: int = 64,
+    health_check_period_s: float = 10.0,
+):
+    """Wrap the FastAPI app in a :func:`@serve.deployment`.
+
+    Returns the configured deployment binding (call ``serve.run(binding)``
+    to launch).
+
+    Raises
+    ------
+    RuntimeError
+        If ``ray`` / ``ray.serve`` aren't installed.
+    """
+    bundle = _check_ray_available()
+    if bundle is None:
+        msg = "Ray Serve is not installed; install with: pip install -e '.[serve]'"
+        raise RuntimeError(msg)
+    _, serve = bundle
+
+    @serve.deployment(
+        num_replicas=num_replicas,
+        ray_actor_options={"num_cpus": num_cpus_per_replica},
+        max_ongoing_requests=max_ongoing_requests,
+        health_check_period_s=health_check_period_s,
+    )
+    @serve.ingress(fastapi_app)
+    class FraudDetectionDeployment:
+        """Ray Serve replica wrapping the FastAPI app.
+
+        Each replica owns its own :class:`FraudPredictor`, Redis client,
+        and Kafka producer (set up by the FastAPI lifespan when the
+        wrapped app boots).
+        """
+
+        def __init__(self) -> None:
+            log.info("ray_serve_replica_started")
+
+    return FraudDetectionDeployment.bind()
+
+
+def run_deployment(
+    *,
+    num_replicas: int = 1,
+    host: str = "0.0.0.0",
+    port: int = 8000,
+    blocking: bool = True,
+) -> None:
+    """One-shot helper for ``scripts/serve.py --ray``.
+
+    Starts a local Ray cluster (or attaches to an existing one), launches
+    the deployment, and blocks until interrupted.
+    """
+    bundle = _check_ray_available()
+    if bundle is None:
+        msg = "Ray Serve is not installed; install with: pip install -e '.[serve]'"
+        raise RuntimeError(msg)
+    ray, serve = bundle
+
+    if not ray.is_initialized():
+        ray.init(ignore_reinit_error=True, log_to_driver=False)
+        log.info("ray_initialized")
+
+    serve.start(
+        http_options={"host": host, "port": port},
+        detached=False,
+    )
+    deployment = build_deployment(num_replicas=num_replicas)
+    handle = serve.run(deployment, name="fraud_detection")
+    log.info("ray_serve_running", host=host, port=port, num_replicas=num_replicas)
+
+    if not blocking:
+        return handle
+
+    import time
+
+    try:
+        while True:
+            time.sleep(60)
+    except KeyboardInterrupt:
+        log.info("ray_serve_shutdown_signal")
+    finally:
+        serve.shutdown()
+        ray.shutdown()
+        log.info("ray_serve_stopped")
+
+
+__all__ = ["build_deployment", "run_deployment"]

--- a/src/fraud_detection/serving/redis_cache.py
+++ b/src/fraud_detection/serving/redis_cache.py
@@ -1,0 +1,226 @@
+"""Embedding cache with a graceful in-memory fallback.
+
+Phase 4's hot path (~50ms budget) needs sub-millisecond reads of the GNN
+embedding for the requested card. In production we hit Redis; in tests
+and on local CPU runs Redis may not be available, so we transparently
+fall back to a thread-safe in-memory dict.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any
+
+import numpy as np
+
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class EmbeddingCache:
+    """Stores per-card 64-d GNN embeddings with TTL support.
+
+    ``connect()`` tries Redis first, falls back to a local dict. Callers
+    don't need to know which backend is active -- ``get`` and ``set``
+    have the same semantics either way.
+    """
+
+    DEFAULT_TTL_SECONDS = 3600  # 1 hour
+    KEY_PREFIX = "meshwatch:emb:"
+
+    def __init__(
+        self,
+        url: str | None = None,
+        *,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        embedding_dim: int = 64,
+    ) -> None:
+        self.url = url
+        self.ttl_seconds = ttl_seconds
+        self.embedding_dim = embedding_dim
+        self._redis: Any | None = None
+        self._lock = threading.Lock()
+        self._mem: dict[str, tuple[float, np.ndarray]] = {}
+        self._connected = False
+
+    # ------------------------------------------------------------------
+    # connect / status
+    # ------------------------------------------------------------------
+
+    def connect(self) -> bool:
+        """Try Redis; on failure fall back to in-memory store. Always
+        returns the *operational* status (whether the cache is usable),
+        not whether Redis itself was reached."""
+        if not self.url:
+            log.info("embedding_cache_in_memory_no_url")
+            self._connected = True
+            return True
+        try:
+            import redis
+
+            client = redis.Redis.from_url(self.url, socket_timeout=2.0)
+            client.ping()
+            self._redis = client
+            self._connected = True
+            log.info("redis_connected", url=self.url)
+        except Exception as exc:
+            log.warning("redis_unavailable_using_in_memory", error=str(exc))
+            self._redis = None
+            self._connected = True
+        return self._connected
+
+    def is_redis(self) -> bool:
+        return self._redis is not None
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    # ------------------------------------------------------------------
+    # core API
+    # ------------------------------------------------------------------
+
+    def _key(self, card_id: int | str) -> str:
+        return f"{self.KEY_PREFIX}{card_id}"
+
+    def get(self, card_id: int | str) -> np.ndarray | None:
+        """Return the cached embedding, or ``None`` if missing/expired."""
+        key = self._key(card_id)
+        if self._redis is not None:
+            try:
+                blob = self._redis.get(key)
+            except Exception as exc:
+                log.warning("redis_get_failed", error=str(exc))
+                return None
+            if blob is None:
+                return None
+            return np.frombuffer(blob, dtype=np.float32)
+
+        # In-memory path with manual TTL.
+        with self._lock:
+            entry = self._mem.get(key)
+            if entry is None:
+                return None
+            expires_at, vec = entry
+            if expires_at < time.time():
+                self._mem.pop(key, None)
+                return None
+            return vec
+
+    def set(
+        self,
+        card_id: int | str,
+        embedding: np.ndarray,
+        *,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        """Store ``embedding`` under ``card_id`` with the configured TTL."""
+        if embedding.ndim != 1:
+            embedding = embedding.reshape(-1)
+        if embedding.dtype != np.float32:
+            embedding = embedding.astype(np.float32)
+        if embedding.shape[0] != self.embedding_dim:
+            log.warning(
+                "embedding_dim_mismatch",
+                expected=self.embedding_dim,
+                got=int(embedding.shape[0]),
+            )
+        ttl = ttl_seconds if ttl_seconds is not None else self.ttl_seconds
+        key = self._key(card_id)
+
+        if self._redis is not None:
+            try:
+                self._redis.setex(key, ttl, embedding.tobytes())
+            except Exception as exc:
+                log.warning("redis_set_failed", error=str(exc))
+            return
+
+        with self._lock:
+            self._mem[key] = (time.time() + ttl, embedding)
+
+    def delete(self, card_id: int | str) -> None:
+        key = self._key(card_id)
+        if self._redis is not None:
+            try:
+                self._redis.delete(key)
+            except Exception as exc:
+                log.warning("redis_delete_failed", error=str(exc))
+            return
+        with self._lock:
+            self._mem.pop(key, None)
+
+    def clear(self) -> None:
+        if self._redis is not None:
+            try:
+                # Only clear our own keys, never the whole DB.
+                cursor = 0
+                while True:
+                    cursor, keys = self._redis.scan(cursor=cursor, match=f"{self.KEY_PREFIX}*")
+                    if keys:
+                        self._redis.delete(*keys)
+                    if cursor == 0:
+                        break
+            except Exception as exc:
+                log.warning("redis_clear_failed", error=str(exc))
+            return
+        with self._lock:
+            self._mem.clear()
+
+    def size(self) -> int:
+        if self._redis is not None:
+            try:
+                return sum(1 for _ in self._redis.scan_iter(match=f"{self.KEY_PREFIX}*"))
+            except Exception:
+                return 0
+        with self._lock:
+            return len(self._mem)
+
+    # ------------------------------------------------------------------
+    # bulk warm-up (pre-load embeddings extracted from the GNN)
+    # ------------------------------------------------------------------
+
+    def warm_up(
+        self,
+        card_ids: list[int | str],
+        embeddings: np.ndarray,
+        *,
+        ttl_seconds: int | None = None,
+    ) -> int:
+        """Bulk-load cached embeddings (e.g. at server startup).
+
+        Returns the number of cache entries written.
+        """
+        if embeddings.ndim != 2 or embeddings.shape[0] != len(card_ids):
+            msg = (
+                f"warm_up: card_ids ({len(card_ids)}) must match "
+                f"embeddings.shape[0] ({embeddings.shape[0]})"
+            )
+            raise ValueError(msg)
+        n_written = 0
+        for cid, vec in zip(card_ids, embeddings, strict=True):
+            self.set(cid, vec, ttl_seconds=ttl_seconds)
+            n_written += 1
+        log.info("embedding_cache_warmup_done", n=n_written)
+        return n_written
+
+    # ------------------------------------------------------------------
+    # serialisation helpers (used by tests + diagnostics)
+    # ------------------------------------------------------------------
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "backend": "redis" if self.is_redis() else "in_memory",
+            "size": self.size(),
+            "ttl_seconds": self.ttl_seconds,
+            "embedding_dim": self.embedding_dim,
+            "connected": self._connected,
+        }
+
+    def __repr__(self) -> str:
+        return f"EmbeddingCache({json.dumps(self.stats())})"
+
+
+__all__ = ["EmbeddingCache"]

--- a/src/fraud_detection/serving/schemas.py
+++ b/src/fraud_detection/serving/schemas.py
@@ -1,0 +1,196 @@
+"""Pydantic request/response schemas for the fraud-detection serving API.
+
+These mirror the public contract documented in README/Phase 4 of the plan.
+The shapes here drive both FastAPI's auto-generated OpenAPI docs and the
+TypeScript client used by the dashboard in Phase 6.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class TransactionRequest(BaseModel):
+    """A single transaction submitted for fraud scoring.
+
+    All optional fields mirror IEEE-CIS feature names. Anything unknown at
+    request time is filled in by the upstream pre-processing pipeline.
+    """
+
+    model_config = ConfigDict(extra="allow")  # tolerate extra V*/D*/M*/id_* fields
+
+    # Mandatory identifiers
+    transaction_id: int | str = Field(..., description="Unique transaction identifier")
+    transaction_dt: int = Field(..., ge=0, description="Seconds since the IEEE-CIS reference epoch")
+    transaction_amt: float = Field(..., ge=0.0, description="Transaction amount in USD")
+    product_cd: str = Field("W", description="Product type (W/C/H/S/R)")
+
+    # Card / address
+    card1: int | None = None
+    card2: float | None = None
+    card3: float | None = None
+    card4: str | None = None
+    card5: float | None = None
+    card6: str | None = None
+    addr1: float | None = None
+    addr2: float | None = None
+    dist1: float | None = None
+    dist2: float | None = None
+
+    # Email
+    p_emaildomain: str | None = Field(default=None, alias="P_emaildomain")
+    r_emaildomain: str | None = Field(default=None, alias="R_emaildomain")
+
+    # Identity (subset)
+    device_type: str | None = Field(default=None, alias="DeviceType")
+    device_info: str | None = Field(default=None, alias="DeviceInfo")
+
+    # Optional: client-supplied wall-clock timestamp (ISO-8601). Used for
+    # logging + temporal-feature freshness sanity checks.
+    received_at: datetime | None = None
+
+    @field_validator("transaction_id", mode="before")
+    @classmethod
+    def _normalise_id(cls, v: Any) -> int | str:
+        # Accept ints from old IEEE-CIS dumps and strings (UUIDs) from
+        # production producers.
+        if isinstance(v, (int, str)):
+            return v
+        return str(v)
+
+
+class BatchPredictRequest(BaseModel):
+    """Up to ``MAX_BATCH_SIZE`` transactions in one round-trip."""
+
+    MAX_BATCH_SIZE: int = Field(default=100, exclude=True)
+    transactions: list[TransactionRequest] = Field(..., min_length=1, max_length=100)
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class FeatureContribution(BaseModel):
+    """One row of the SHAP-style explanation table."""
+
+    feature: str
+    value: float
+    contribution: float
+
+
+class FraudPrediction(BaseModel):
+    """Scoring result for one transaction."""
+
+    transaction_id: int | str
+    fraud_probability: float = Field(..., ge=0.0, le=1.0)
+    fraud_score: float = Field(..., ge=0.0, le=1.0, description="Calibrated probability")
+    risk_level: Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+    is_fraud_predicted: bool
+    threshold: float = Field(default=0.5, ge=0.0, le=1.0)
+
+    # Optional explanation -- populated when SHAP is available.
+    top_features: list[FeatureContribution] = Field(default_factory=list)
+
+    # Latency breakdown in milliseconds (per the Phase 4 budget table).
+    latency_ms: dict[str, float] = Field(default_factory=dict)
+
+    # Model + serving metadata.
+    model_version: str = "v0.3.0-gnn-model"
+    served_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class BatchPredictResponse(BaseModel):
+    predictions: list[FraudPrediction]
+    n_processed: int
+    n_alerts: int = Field(0, description="Predictions exceeding the alert threshold")
+    elapsed_ms: float
+
+
+# ---------------------------------------------------------------------------
+# System-status models
+# ---------------------------------------------------------------------------
+
+
+class HealthStatus(BaseModel):
+    status: Literal["ok", "degraded", "down"] = "ok"
+    model_loaded: bool = False
+    redis_connected: bool = False
+    kafka_connected: bool = False
+    ray_serve_active: bool = False
+    uptime_seconds: float = 0.0
+    version: str = "v0.4.0-serving-pipeline"
+
+
+class ModelInfoResponse(BaseModel):
+    """Returned by ``GET /api/v1/model/info``."""
+
+    model_config = ConfigDict(protected_namespaces=())
+
+    model_version: str
+    n_parameters: int
+    embedding_dim: int
+    n_features: int
+    feature_columns: list[str]
+    edge_types: list[str]
+    node_types: list[str]
+    train_metrics: dict[str, float] = Field(default_factory=dict)
+    feature_importance_top_k: dict[str, float] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Streaming / WebSocket
+# ---------------------------------------------------------------------------
+
+
+class FraudAlert(BaseModel):
+    """Pushed to the ``fraud_alerts`` Kafka topic and the ``/ws/alerts``
+    WebSocket whenever a transaction crosses the alert threshold."""
+
+    transaction_id: int | str
+    fraud_score: float
+    risk_level: Literal["MEDIUM", "HIGH", "CRITICAL"]
+    transaction_amt: float
+    card_id: str | int | None = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    top_features: list[FeatureContribution] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ALERT_THRESHOLD: float = 0.7
+"""Predictions at or above this score trigger a Kafka alert + WS push."""
+
+
+def risk_level(score: float) -> Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"]:
+    """Bin a fraud score into the analyst-facing 4-level scale."""
+    if score >= 0.9:
+        return "CRITICAL"
+    if score >= 0.7:
+        return "HIGH"
+    if score >= 0.4:
+        return "MEDIUM"
+    return "LOW"
+
+
+__all__ = [
+    "ALERT_THRESHOLD",
+    "BatchPredictRequest",
+    "BatchPredictResponse",
+    "FeatureContribution",
+    "FraudAlert",
+    "FraudPrediction",
+    "HealthStatus",
+    "ModelInfoResponse",
+    "TransactionRequest",
+    "risk_level",
+]

--- a/src/fraud_detection/streaming/__init__.py
+++ b/src/fraud_detection/streaming/__init__.py
@@ -1,1 +1,10 @@
-"""Kafka streaming producer/consumer (Phase 4)."""
+"""Kafka producer + consumer for fraud-alert streaming (Phase 4).
+
+Both classes degrade gracefully to an in-memory queue when no broker is
+reachable, so unit tests + local laptop dev work without docker-compose.
+"""
+
+from fraud_detection.streaming.kafka_consumer import AlertHandler, FraudAlertConsumer
+from fraud_detection.streaming.kafka_producer import FraudAlertProducer
+
+__all__ = ["AlertHandler", "FraudAlertConsumer", "FraudAlertProducer"]

--- a/src/fraud_detection/streaming/kafka_consumer.py
+++ b/src/fraud_detection/streaming/kafka_consumer.py
@@ -1,0 +1,274 @@
+"""Kafka consumer for fraud alerts -- poll loop with WebSocket fan-out.
+
+The Phase 4 architecture uses Kafka as the durable buffer between the
+scoring service and any downstream consumer (the dashboard's
+``/ws/alerts`` endpoint, the agent's investigation queue, etc.). This
+module exposes :class:`FraudAlertConsumer` which:
+
+* Subscribes to one or more alert topics (default ``fraud_alerts``).
+* Calls a user-supplied callback for each decoded :class:`FraudAlert`.
+* Falls back to an in-process broker stub when Kafka isn't reachable so
+  tests + local dev work without docker-compose.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import threading
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fraud_detection.serving.schemas import FraudAlert
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+AlertHandler = Callable[[FraudAlert], None] | Callable[[FraudAlert], Awaitable[None]]
+
+
+class FraudAlertConsumer:
+    """Background poll loop that feeds alerts into a callback.
+
+    Run with :meth:`start` (returns immediately, dispatch happens on a
+    daemon thread) and stop with :meth:`stop`. For async use cases, see
+    :meth:`consume_async`.
+    """
+
+    def __init__(
+        self,
+        *,
+        bootstrap_servers: str | None = None,
+        topic: str = "fraud_alerts",
+        group_id: str = "meshwatch-api",
+        handler: AlertHandler | None = None,
+        poll_timeout_seconds: float = 1.0,
+    ) -> None:
+        self.bootstrap_servers = bootstrap_servers
+        self.topic = topic
+        self.group_id = group_id
+        self.handler = handler
+        self.poll_timeout_seconds = poll_timeout_seconds
+
+        self._consumer: Any | None = None
+        self._stop_evt = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._connected = False
+        self._n_consumed = 0
+        self._n_errors = 0
+
+        # in-memory fallback: peer producers register here and we drain.
+        self._mem_buffer: list[FraudAlert] = []
+        self._mem_lock = threading.Lock()
+
+        # Pending fire-and-forget handler tasks; tracked so the loop
+        # doesn't GC them mid-execution (cf. RUF006 / asyncio docs).
+        self._pending_tasks: set[asyncio.Task] = set()
+
+    # ------------------------------------------------------------------
+    # connect
+    # ------------------------------------------------------------------
+
+    def connect(self) -> bool:
+        if not self.bootstrap_servers:
+            log.info("kafka_consumer_in_memory_no_bootstrap")
+            self._connected = True
+            return True
+        try:
+            from confluent_kafka import Consumer
+
+            self._consumer = Consumer(
+                {
+                    "bootstrap.servers": self.bootstrap_servers,
+                    "group.id": self.group_id,
+                    "auto.offset.reset": "latest",
+                    "enable.auto.commit": True,
+                    "session.timeout.ms": 6000,
+                }
+            )
+            self._consumer.subscribe([self.topic])
+            self._connected = True
+            log.info("kafka_consumer_connected", topic=self.topic, group=self.group_id)
+        except Exception as exc:
+            log.warning("kafka_consumer_unavailable_using_in_memory", error=str(exc))
+            self._consumer = None
+            self._connected = True
+        return self._connected
+
+    @property
+    def is_kafka(self) -> bool:
+        return self._consumer is not None
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    # ------------------------------------------------------------------
+    # in-memory bridge (used when there's no Kafka)
+    # ------------------------------------------------------------------
+
+    def push_in_memory(self, alert: FraudAlert) -> None:
+        """Inject an alert into the in-memory buffer (used by tests and the
+        FastAPI app's local fan-out when Kafka isn't reachable)."""
+        with self._mem_lock:
+            self._mem_buffer.append(alert)
+
+    def _drain_in_memory(self) -> list[FraudAlert]:
+        with self._mem_lock:
+            out = list(self._mem_buffer)
+            self._mem_buffer.clear()
+            return out
+
+    # ------------------------------------------------------------------
+    # blocking poll (sync)
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Spawn a daemon thread that runs the poll loop."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_evt.clear()
+        self._thread = threading.Thread(
+            target=self._run_blocking_loop,
+            name="meshwatch-kafka-consumer",
+            daemon=True,
+        )
+        self._thread.start()
+        log.info("kafka_consumer_started")
+
+    def stop(self) -> None:
+        self._stop_evt.set()
+        if self._thread:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        if self._consumer is not None:
+            with contextlib.suppress(Exception):
+                self._consumer.close()
+            self._consumer = None
+        log.info("kafka_consumer_stopped", n_consumed=self._n_consumed)
+
+    def _run_blocking_loop(self) -> None:
+        while not self._stop_evt.is_set():
+            try:
+                if self._consumer is not None:
+                    msg = self._consumer.poll(self.poll_timeout_seconds)
+                    if msg is None:
+                        continue
+                    if msg.error():
+                        log.warning("kafka_consumer_msg_error", error=str(msg.error()))
+                        self._n_errors += 1
+                        continue
+                    payload = msg.value()
+                    self._dispatch_payload(payload)
+                else:
+                    # in-memory fallback: drain buffer
+                    for a in self._drain_in_memory():
+                        self._dispatch_alert(a)
+                    time.sleep(self.poll_timeout_seconds)
+            except Exception as exc:
+                log.exception("kafka_consumer_loop_error", error=str(exc))
+                self._n_errors += 1
+                time.sleep(self.poll_timeout_seconds)
+
+    # ------------------------------------------------------------------
+    # async variant (used by FastAPI WebSocket handler)
+    # ------------------------------------------------------------------
+
+    async def consume_async(self, handler: AlertHandler) -> None:
+        """Yield alerts via an async-compatible handler.
+
+        Runs until :meth:`stop` is called. Designed to live in an
+        ``asyncio.Task`` started from a FastAPI lifespan / dependency.
+        """
+        loop = asyncio.get_running_loop()
+        while not self._stop_evt.is_set():
+            alerts: list[FraudAlert] = []
+            if self._consumer is not None:
+                # Run blocking poll on a worker thread to avoid blocking the loop.
+                msg = await loop.run_in_executor(
+                    None, self._consumer.poll, self.poll_timeout_seconds
+                )
+                if msg is None:
+                    continue
+                if msg.error():
+                    log.warning("kafka_consumer_msg_error", error=str(msg.error()))
+                    self._n_errors += 1
+                    continue
+                payload = msg.value()
+                a = self._decode(payload)
+                if a is not None:
+                    alerts.append(a)
+            else:
+                alerts = self._drain_in_memory()
+                if not alerts:
+                    await asyncio.sleep(self.poll_timeout_seconds)
+                    continue
+
+            for alert in alerts:
+                self._n_consumed += 1
+                result = handler(alert)
+                if asyncio.iscoroutine(result):
+                    await result
+
+    # ------------------------------------------------------------------
+    # decode + dispatch helpers
+    # ------------------------------------------------------------------
+
+    def _decode(self, payload: bytes | str | None) -> FraudAlert | None:
+        if not payload:
+            return None
+        if isinstance(payload, (bytes, bytearray)):
+            payload = payload.decode("utf-8", errors="replace")
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            log.warning("kafka_consumer_decode_failed", error=str(exc))
+            return None
+        try:
+            return FraudAlert.model_validate(data)
+        except Exception as exc:
+            log.warning("kafka_consumer_schema_mismatch", error=str(exc))
+            return None
+
+    def _dispatch_payload(self, payload: bytes | str | None) -> None:
+        a = self._decode(payload)
+        if a is not None:
+            self._dispatch_alert(a)
+
+    def _dispatch_alert(self, alert: FraudAlert) -> None:
+        self._n_consumed += 1
+        if self.handler is None:
+            return
+        try:
+            result = self.handler(alert)
+            if asyncio.iscoroutine(result):
+                # Fire-and-forget on the running loop if any. We track the
+                # task so the running loop doesn't GC it mid-execution; we
+                # don't need to await it (the handler is one-shot per alert).
+                try:
+                    loop = asyncio.get_running_loop()
+                    task = loop.create_task(result)
+                    self._pending_tasks.add(task)
+                    task.add_done_callback(self._pending_tasks.discard)
+                except RuntimeError:
+                    # No running loop on this thread -- run synchronously.
+                    asyncio.run(result)
+        except Exception:
+            log.exception("kafka_consumer_handler_error")
+            self._n_errors += 1
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "backend": "kafka" if self.is_kafka else "in_memory",
+            "topic": self.topic,
+            "group_id": self.group_id,
+            "n_consumed": self._n_consumed,
+            "n_errors": self._n_errors,
+            "connected": self._connected,
+            "in_memory_buffer_size": len(self._mem_buffer),
+        }
+
+
+__all__ = ["AlertHandler", "FraudAlertConsumer"]

--- a/src/fraud_detection/streaming/kafka_producer.py
+++ b/src/fraud_detection/streaming/kafka_producer.py
@@ -1,0 +1,195 @@
+"""Kafka producer for fraud alerts.
+
+Wraps ``confluent_kafka.Producer`` and falls back to an in-process queue
+when no broker is reachable -- the FastAPI app stays operational on
+laptops without Kafka, and tests don't need a docker-compose stack.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from collections.abc import Callable
+from typing import Any
+
+from fraud_detection.serving.schemas import FraudAlert
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class FraudAlertProducer:
+    """Publish :class:`FraudAlert` events to the ``fraud_alerts`` topic.
+
+    Parameters
+    ----------
+    bootstrap_servers
+        Kafka bootstrap string (e.g. ``"localhost:9092"``). If ``None``
+        or unreachable, falls back to an in-memory queue.
+    topic
+        Topic to publish to (default ``fraud_alerts``).
+    flush_timeout_seconds
+        Default flush timeout used by :meth:`flush` and :meth:`close`.
+    on_delivery
+        Optional delivery-report callback. Receives ``(err, msg)`` per
+        ``confluent_kafka`` convention; called on the producer's poll
+        thread.
+    """
+
+    DEFAULT_TOPIC = "fraud_alerts"
+
+    def __init__(
+        self,
+        *,
+        bootstrap_servers: str | None = None,
+        topic: str = DEFAULT_TOPIC,
+        client_id: str = "meshwatch-api",
+        flush_timeout_seconds: float = 5.0,
+        on_delivery: Callable[[Any, Any], None] | None = None,
+    ) -> None:
+        self.bootstrap_servers = bootstrap_servers
+        self.topic = topic
+        self.client_id = client_id
+        self.flush_timeout_seconds = flush_timeout_seconds
+        self._on_delivery = on_delivery
+        self._producer: Any | None = None
+        self._mem_queue: deque[FraudAlert] = deque(maxlen=10_000)
+        self._lock = threading.Lock()
+        self._connected = False
+        self._n_published = 0
+        self._n_failures = 0
+
+    # ------------------------------------------------------------------
+    # connect / status
+    # ------------------------------------------------------------------
+
+    def connect(self) -> bool:
+        """Try to construct a confluent_kafka.Producer; fall back on failure."""
+        if not self.bootstrap_servers:
+            log.info("kafka_producer_in_memory_no_bootstrap")
+            self._connected = True
+            return True
+        try:
+            from confluent_kafka import Producer
+
+            conf = {
+                "bootstrap.servers": self.bootstrap_servers,
+                "client.id": self.client_id,
+                "linger.ms": 5,
+                "compression.type": "snappy",
+                "enable.idempotence": True,
+                "acks": "all",
+                "message.timeout.ms": 5000,
+            }
+            self._producer = Producer(conf)
+            # Test connectivity with a metadata fetch (cheap, no message).
+            self._producer.list_topics(timeout=2.0)
+            self._connected = True
+            log.info("kafka_producer_connected", bootstrap=self.bootstrap_servers)
+        except Exception as exc:
+            log.warning("kafka_producer_unavailable_using_in_memory", error=str(exc))
+            self._producer = None
+            self._connected = True  # in-memory mode is "operational"
+        return self._connected
+
+    @property
+    def is_kafka(self) -> bool:
+        return self._producer is not None
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    # ------------------------------------------------------------------
+    # publish
+    # ------------------------------------------------------------------
+
+    def publish(self, alert: FraudAlert) -> bool:
+        """Send one alert. Returns True if accepted (not necessarily delivered)."""
+        if self._producer is not None:
+            payload = alert.model_dump_json().encode("utf-8")
+            key = str(alert.transaction_id).encode("utf-8")
+            try:
+                self._producer.produce(
+                    topic=self.topic,
+                    value=payload,
+                    key=key,
+                    on_delivery=self._on_delivery_wrapper,
+                )
+                # poll(0) lets the librdkafka background thread fire the
+                # delivery callbacks without blocking.
+                self._producer.poll(0)
+                with self._lock:
+                    self._n_published += 1
+                return True
+            except BufferError as exc:
+                log.warning("kafka_buffer_full", error=str(exc))
+                with self._lock:
+                    self._n_failures += 1
+                return False
+            except Exception as exc:
+                log.warning("kafka_produce_failed", error=str(exc))
+                with self._lock:
+                    self._n_failures += 1
+                return False
+
+        # In-memory path (testing / no broker).
+        with self._lock:
+            self._mem_queue.append(alert)
+            self._n_published += 1
+        return True
+
+    def _on_delivery_wrapper(self, err: Any, msg: Any) -> None:
+        if err is not None:
+            log.warning("kafka_delivery_failed", error=str(err))
+            with self._lock:
+                self._n_failures += 1
+        if self._on_delivery is not None:
+            try:
+                self._on_delivery(err, msg)
+            except Exception:
+                log.exception("kafka_on_delivery_callback_error")
+
+    # ------------------------------------------------------------------
+    # housekeeping
+    # ------------------------------------------------------------------
+
+    def flush(self, timeout: float | None = None) -> int:
+        """Force-flush pending messages. Returns # of messages still in the queue."""
+        if self._producer is None:
+            return 0
+        return int(self._producer.flush(timeout or self.flush_timeout_seconds))
+
+    def close(self) -> None:
+        """Flush + drop the underlying producer."""
+        if self._producer is not None:
+            try:
+                self._producer.flush(self.flush_timeout_seconds)
+            except Exception as exc:
+                log.warning("kafka_close_flush_failed", error=str(exc))
+            self._producer = None
+        self._connected = False
+
+    # Test helpers ------------------------------------------------------
+
+    def drain_in_memory(self) -> list[FraudAlert]:
+        """Return + clear the in-memory queue (no-op in Kafka mode)."""
+        if self._producer is not None:
+            return []
+        with self._lock:
+            out = list(self._mem_queue)
+            self._mem_queue.clear()
+            return out
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "backend": "kafka" if self.is_kafka else "in_memory",
+            "topic": self.topic,
+            "n_published": self._n_published,
+            "n_failures": self._n_failures,
+            "connected": self._connected,
+            "in_memory_queue_size": len(self._mem_queue),
+        }
+
+
+__all__ = ["FraudAlertProducer"]

--- a/tests/unit/test_kafka_streaming.py
+++ b/tests/unit/test_kafka_streaming.py
@@ -1,0 +1,151 @@
+"""Tests for the Kafka producer + consumer in-memory fallback."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+from fraud_detection.serving.schemas import FraudAlert
+from fraud_detection.streaming import FraudAlertConsumer, FraudAlertProducer
+
+
+def _alert(i: int = 1, score: float = 0.85) -> FraudAlert:
+    return FraudAlert(
+        transaction_id=i,
+        fraud_score=score,
+        risk_level="HIGH",
+        transaction_amt=42.0,
+        card_id="card-1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Producer in-memory fallback
+# ---------------------------------------------------------------------------
+
+
+def test_producer_connects_without_broker():
+    p = FraudAlertProducer(bootstrap_servers=None)
+    assert p.connect()
+    assert not p.is_kafka
+    assert p.connected
+
+
+def test_producer_publish_in_memory():
+    p = FraudAlertProducer(bootstrap_servers=None)
+    p.connect()
+    assert p.publish(_alert(1))
+    assert p.publish(_alert(2))
+    drained = p.drain_in_memory()
+    assert len(drained) == 2
+    assert drained[0].transaction_id == 1
+
+
+def test_producer_drain_clears_buffer():
+    p = FraudAlertProducer(bootstrap_servers=None)
+    p.connect()
+    p.publish(_alert(1))
+    p.drain_in_memory()
+    assert p.drain_in_memory() == []
+
+
+def test_producer_stats_track_publishes():
+    p = FraudAlertProducer(bootstrap_servers=None)
+    p.connect()
+    for i in range(3):
+        p.publish(_alert(i))
+    stats = p.stats()
+    assert stats["backend"] == "in_memory"
+    assert stats["n_published"] == 3
+    assert stats["topic"] == "fraud_alerts"
+
+
+def test_producer_dead_broker_falls_back(monkeypatch):
+    """Unreachable broker should not crash; we end up in in-memory mode."""
+    p = FraudAlertProducer(bootstrap_servers="127.0.0.1:1")
+    assert p.connect()
+    assert p.connected
+    # Whether it ends up in kafka or in-memory mode depends on the local
+    # confluent_kafka behavior; what matters is that publish() doesn't
+    # raise for the in-memory fallback path.
+    p.publish(_alert(1))
+
+
+def test_producer_close_is_safe_when_not_connected():
+    p = FraudAlertProducer(bootstrap_servers=None)
+    # close before connect should be a no-op
+    p.close()
+    assert not p.connected
+
+
+# ---------------------------------------------------------------------------
+# Consumer in-memory fallback
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_connects_without_broker():
+    c = FraudAlertConsumer(bootstrap_servers=None)
+    assert c.connect()
+    assert not c.is_kafka
+
+
+def test_consumer_in_memory_push_drain():
+    c = FraudAlertConsumer(bootstrap_servers=None)
+    c.connect()
+    c.push_in_memory(_alert(1))
+    c.push_in_memory(_alert(2))
+    drained = c._drain_in_memory()
+    assert len(drained) == 2
+
+
+def test_consumer_async_loop_dispatches_to_handler():
+    c = FraudAlertConsumer(bootstrap_servers=None, poll_timeout_seconds=0.01)
+    c.connect()
+    c.push_in_memory(_alert(1))
+    c.push_in_memory(_alert(2))
+
+    received: list[FraudAlert] = []
+
+    async def handler(alert: FraudAlert) -> None:
+        received.append(alert)
+        if len(received) >= 2:
+            c.stop()  # signal the loop to exit
+
+    async def runner():
+        # Wrap the async consume loop in a timeout so the test can never hang.
+        await asyncio.wait_for(c.consume_async(handler), timeout=2.0)
+
+    with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+        asyncio.run(runner())
+
+    assert len(received) == 2
+    assert received[0].transaction_id == 1
+    assert received[1].transaction_id == 2
+
+
+def test_consumer_decode_handles_bad_json():
+    c = FraudAlertConsumer(bootstrap_servers=None)
+    assert c._decode(b"not json {") is None
+    assert c._decode(b"") is None
+    assert c._decode(None) is None
+
+
+def test_consumer_decode_validates_schema():
+    c = FraudAlertConsumer(bootstrap_servers=None)
+    # Valid alert
+    a = _alert(7).model_dump_json().encode()
+    decoded = c._decode(a)
+    assert decoded is not None
+    assert decoded.transaction_id == 7
+    # Wrong shape -> rejected
+    assert c._decode(b'{"foo": "bar"}') is None
+
+
+def test_consumer_stats():
+    c = FraudAlertConsumer(bootstrap_servers=None, group_id="test-group")
+    c.connect()
+    c.push_in_memory(_alert(1))
+    s = c.stats()
+    assert s["backend"] == "in_memory"
+    assert s["group_id"] == "test-group"
+    assert s["in_memory_buffer_size"] == 1

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -1,0 +1,150 @@
+"""Tests for ``fraud_detection.serving.predictor.FraudPredictor``."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from fraud_detection.serving.predictor import FraudPredictor
+from fraud_detection.serving.redis_cache import EmbeddingCache
+from fraud_detection.serving.schemas import TransactionRequest
+
+
+def _stub_xgb(score: float = 0.5) -> MagicMock:
+    """Return a mock xgb that yields the given score for any input."""
+    xgb = MagicMock()
+    xgb.predict_proba.side_effect = lambda X: np.full(X.shape[0], score, dtype=np.float32)
+    return xgb
+
+
+def _stub_ensemble(score: float = 0.5):
+    ens = MagicMock()
+    ens.xgb = _stub_xgb(score)
+    ens.gnn = MagicMock()
+    ens.gnn.embedding_dim = 4
+    ens.feature_columns = [f"gnn_emb_{i:03d}" for i in range(4)] + ["TransactionAmt", "addr1"]
+    return ens
+
+
+@pytest.fixture
+def cache() -> EmbeddingCache:
+    c = EmbeddingCache(url=None, embedding_dim=4)
+    c.connect()
+    return c
+
+
+def test_predict_one_returns_expected_shape(cache):
+    ens = _stub_ensemble(score=0.85)
+    p = FraudPredictor(
+        ensemble=ens,
+        embedding_cache=cache,
+        feature_columns=ens.feature_columns,
+        enable_shap=False,
+    )
+    req = TransactionRequest(transaction_id=1, transaction_dt=10, transaction_amt=100.0, card1=42)
+    out = p.predict_one(req)
+    assert out.transaction_id == 1
+    assert out.fraud_score == pytest.approx(0.85)
+    assert out.is_fraud_predicted  # 0.85 > default 0.7
+    assert out.risk_level == "HIGH"
+
+
+def test_predict_one_below_threshold(cache):
+    ens = _stub_ensemble(score=0.1)
+    p = FraudPredictor(
+        ensemble=ens,
+        embedding_cache=cache,
+        feature_columns=ens.feature_columns,
+        enable_shap=False,
+    )
+    req = TransactionRequest(transaction_id=1, transaction_dt=10, transaction_amt=20.0)
+    out = p.predict_one(req)
+    assert not out.is_fraud_predicted
+    assert out.risk_level == "LOW"
+
+
+def test_predict_uses_cached_embedding(cache):
+    """If the cache has an embedding for the card, it should be used (not zero)."""
+    ens = _stub_ensemble(score=0.5)
+    p = FraudPredictor(
+        ensemble=ens,
+        embedding_cache=cache,
+        feature_columns=ens.feature_columns,
+        enable_shap=False,
+    )
+    # Pre-warm cache with a known vector for card1=42.
+    cache.set(42, np.arange(4, dtype=np.float32) * 10)
+    req = TransactionRequest(transaction_id=1, transaction_dt=10, transaction_amt=50.0, card1=42)
+    p.predict_one(req)
+    # The mock xgb received the cache vector concatenated with tabular features.
+    # Inspect the call args (last call):
+    last_X = ens.xgb.predict_proba.call_args_list[-1][0][0]
+    np.testing.assert_array_equal(last_X[0, :4], np.arange(4, dtype=np.float32) * 10)
+
+
+def test_predict_zero_embedding_for_cold_card(cache):
+    ens = _stub_ensemble(score=0.5)
+    p = FraudPredictor(
+        ensemble=ens,
+        embedding_cache=cache,
+        feature_columns=ens.feature_columns,
+        enable_shap=False,
+    )
+    req = TransactionRequest(transaction_id=1, transaction_dt=10, transaction_amt=50.0, card1=99999)
+    p.predict_one(req)
+    last_X = ens.xgb.predict_proba.call_args_list[-1][0][0]
+    np.testing.assert_array_equal(last_X[0, :4], np.zeros(4, dtype=np.float32))
+
+
+def test_predict_batch_keeps_order(cache):
+    ens = _stub_ensemble(score=0.5)
+    # Make the score depend on input so we can verify ordering.
+    ens.xgb.predict_proba.side_effect = lambda X: np.linspace(0.0, 1.0, X.shape[0]).astype(
+        np.float32
+    )
+    p = FraudPredictor(
+        ensemble=ens,
+        embedding_cache=cache,
+        feature_columns=ens.feature_columns,
+        enable_shap=False,
+    )
+    reqs = [
+        TransactionRequest(transaction_id=i, transaction_dt=i, transaction_amt=10.0 + i)
+        for i in range(5)
+    ]
+    out = p.predict_batch(reqs)
+    assert [r.transaction_id for r in out] == [0, 1, 2, 3, 4]
+    # Scores should be linspace(0, 1, 5)
+    assert out[0].fraud_score == pytest.approx(0.0)
+    assert out[-1].fraud_score == pytest.approx(1.0, abs=1e-5)
+
+
+def test_predict_latency_breakdown_included(cache):
+    ens = _stub_ensemble(score=0.5)
+    p = FraudPredictor(
+        ensemble=ens,
+        embedding_cache=cache,
+        feature_columns=ens.feature_columns,
+        enable_shap=False,
+    )
+    req = TransactionRequest(transaction_id=1, transaction_dt=10, transaction_amt=10.0)
+    out = p.predict_one(req)
+    for k in ("embedding_ms", "tabular_ms", "xgboost_ms", "total_ms"):
+        assert k in out.latency_ms
+        assert out.latency_ms[k] >= 0
+
+
+def test_predict_info(cache):
+    ens = _stub_ensemble(score=0.5)
+    p = FraudPredictor(
+        ensemble=ens,
+        embedding_cache=cache,
+        feature_columns=ens.feature_columns,
+        enable_shap=False,
+    )
+    info = p.info()
+    assert info["embedding_dim"] == 4
+    assert "cache_stats" in info
+    assert info["shap_enabled"] is False

--- a/tests/unit/test_redis_cache.py
+++ b/tests/unit/test_redis_cache.py
@@ -1,0 +1,106 @@
+"""Tests for ``fraud_detection.serving.redis_cache.EmbeddingCache``."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from fraud_detection.serving.redis_cache import EmbeddingCache
+
+
+@pytest.fixture
+def cache() -> EmbeddingCache:
+    c = EmbeddingCache(url=None, ttl_seconds=60, embedding_dim=8)
+    c.connect()
+    return c
+
+
+def test_in_memory_fallback_connects_without_url():
+    c = EmbeddingCache(url=None)
+    assert c.connect() is True
+    assert c.connected
+    assert not c.is_redis()
+
+
+def test_set_and_get_roundtrip(cache):
+    vec = np.arange(8, dtype=np.float32)
+    cache.set("card-1", vec)
+    out = cache.get("card-1")
+    assert out is not None
+    np.testing.assert_array_equal(out, vec)
+
+
+def test_get_missing_returns_none(cache):
+    assert cache.get("missing") is None
+
+
+def test_ttl_expiry(cache):
+    vec = np.zeros(8, dtype=np.float32)
+    cache.set("ephemeral", vec, ttl_seconds=0)
+    # Brief sleep so the in-memory TTL definitely expires.
+    time.sleep(0.01)
+    assert cache.get("ephemeral") is None
+
+
+def test_size_and_clear(cache):
+    for i in range(5):
+        cache.set(f"k{i}", np.zeros(8, dtype=np.float32))
+    assert cache.size() == 5
+    cache.clear()
+    assert cache.size() == 0
+
+
+def test_delete(cache):
+    cache.set("kkk", np.ones(8, dtype=np.float32))
+    cache.delete("kkk")
+    assert cache.get("kkk") is None
+
+
+def test_dim_mismatch_logs_but_stores(cache):
+    """A wrong-dim embedding should log a warning but not crash."""
+    cache.set("weird", np.zeros(16, dtype=np.float32))
+    out = cache.get("weird")
+    assert out is not None
+    assert out.shape[0] == 16
+
+
+def test_warm_up_bulk_load(cache):
+    ids = ["a", "b", "c"]
+    embs = np.arange(24, dtype=np.float32).reshape(3, 8)
+    n = cache.warm_up(ids, embs)
+    assert n == 3
+    assert cache.size() == 3
+    np.testing.assert_array_equal(cache.get("b"), embs[1])
+
+
+def test_warm_up_shape_mismatch_raises(cache):
+    with pytest.raises(ValueError):
+        cache.warm_up(["a", "b"], np.zeros((3, 8), dtype=np.float32))
+
+
+def test_stats_in_memory(cache):
+    cache.set("k", np.zeros(8, dtype=np.float32))
+    stats = cache.stats()
+    assert stats["backend"] == "in_memory"
+    assert stats["size"] == 1
+    assert stats["embedding_dim"] == 8
+    assert stats["connected"] is True
+
+
+def test_in_memory_dtype_normalisation(cache):
+    """Setting a float64 array should still produce float32 on read."""
+    cache.set("dtype-test", np.ones(8, dtype=np.float64))
+    out = cache.get("dtype-test")
+    assert out.dtype == np.float32
+
+
+def test_redis_failure_falls_back(monkeypatch):
+    """When the URL points at a dead Redis, ``connect`` still succeeds in-memory."""
+    cache = EmbeddingCache(url="redis://127.0.0.1:1/0", embedding_dim=8)
+    assert cache.connect() is True
+    assert cache.connected
+    assert not cache.is_redis()  # fell back to in-memory
+    cache.set("k", np.zeros(8, dtype=np.float32))
+    assert cache.get("k") is not None

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,0 +1,198 @@
+"""Tests for ``fraud_detection.serving.schemas``."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from fraud_detection.serving.schemas import (
+    ALERT_THRESHOLD,
+    BatchPredictRequest,
+    FeatureContribution,
+    FraudAlert,
+    FraudPrediction,
+    HealthStatus,
+    ModelInfoResponse,
+    TransactionRequest,
+    risk_level,
+)
+
+# ---------------------------------------------------------------------------
+# TransactionRequest
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_valid_request():
+    req = TransactionRequest(
+        transaction_id=1,
+        transaction_dt=12345,
+        transaction_amt=42.5,
+    )
+    assert req.transaction_id == 1
+    assert req.product_cd == "W"  # default
+
+
+def test_request_accepts_string_id():
+    req = TransactionRequest(
+        transaction_id="abc-uuid-123",
+        transaction_dt=1,
+        transaction_amt=10.0,
+    )
+    assert req.transaction_id == "abc-uuid-123"
+
+
+def test_request_accepts_extra_v_features():
+    req = TransactionRequest(
+        transaction_id=1,
+        transaction_dt=1,
+        transaction_amt=10.0,
+        V1=0.5,  # extra V-feature passes through
+        V99=-2.0,
+        unknown_field="banana",
+    )
+    dump = req.model_dump()
+    assert dump["V1"] == 0.5
+    assert dump["unknown_field"] == "banana"
+
+
+def test_request_validates_negative_amount():
+    with pytest.raises(ValueError):
+        TransactionRequest(transaction_id=1, transaction_dt=1, transaction_amt=-1.0)
+
+
+def test_request_validates_negative_dt():
+    with pytest.raises(ValueError):
+        TransactionRequest(transaction_id=1, transaction_dt=-1, transaction_amt=10.0)
+
+
+def test_request_aliases_email_fields():
+    req = TransactionRequest(
+        transaction_id=1,
+        transaction_dt=1,
+        transaction_amt=10.0,
+        P_emaildomain="gmail.com",  # alias
+        DeviceType="desktop",
+    )
+    assert req.p_emaildomain == "gmail.com"
+    assert req.device_type == "desktop"
+
+
+# ---------------------------------------------------------------------------
+# BatchPredictRequest
+# ---------------------------------------------------------------------------
+
+
+def _stub_request(i: int = 1) -> TransactionRequest:
+    return TransactionRequest(transaction_id=i, transaction_dt=i, transaction_amt=10.0)
+
+
+def test_batch_request_min_size_one():
+    req = BatchPredictRequest(transactions=[_stub_request(1)])
+    assert len(req.transactions) == 1
+
+
+def test_batch_request_max_size_100():
+    big = [_stub_request(i) for i in range(100)]
+    BatchPredictRequest(transactions=big)  # ok
+    with pytest.raises(ValueError):
+        BatchPredictRequest(transactions=[*big, _stub_request(101)])
+
+
+def test_batch_request_empty_rejected():
+    with pytest.raises(ValueError):
+        BatchPredictRequest(transactions=[])
+
+
+# ---------------------------------------------------------------------------
+# FraudPrediction
+# ---------------------------------------------------------------------------
+
+
+def test_prediction_round_trip_json():
+    pred = FraudPrediction(
+        transaction_id=42,
+        fraud_probability=0.85,
+        fraud_score=0.85,
+        risk_level="HIGH",
+        is_fraud_predicted=True,
+        threshold=0.7,
+        top_features=[FeatureContribution(feature="V1", value=0.5, contribution=0.2)],
+        latency_ms={"total_ms": 12.3},
+    )
+    s = pred.model_dump_json()
+    parsed = FraudPrediction.model_validate_json(s)
+    assert parsed.transaction_id == 42
+    assert parsed.fraud_score == pytest.approx(0.85)
+    assert parsed.top_features[0].feature == "V1"
+
+
+def test_prediction_validates_proba_range():
+    with pytest.raises(ValueError):
+        FraudPrediction(
+            transaction_id=1,
+            fraud_probability=1.5,
+            fraud_score=0.5,
+            risk_level="HIGH",
+            is_fraud_predicted=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# risk_level
+# ---------------------------------------------------------------------------
+
+
+def test_risk_level_buckets():
+    assert risk_level(0.0) == "LOW"
+    assert risk_level(0.39) == "LOW"
+    assert risk_level(0.4) == "MEDIUM"
+    assert risk_level(0.69) == "MEDIUM"
+    assert risk_level(0.7) == "HIGH"
+    assert risk_level(0.89) == "HIGH"
+    assert risk_level(0.9) == "CRITICAL"
+    assert risk_level(1.0) == "CRITICAL"
+
+
+def test_alert_threshold_constant():
+    assert 0.5 < ALERT_THRESHOLD < 1.0
+
+
+# ---------------------------------------------------------------------------
+# FraudAlert + HealthStatus + ModelInfo
+# ---------------------------------------------------------------------------
+
+
+def test_fraud_alert_round_trip():
+    a = FraudAlert(
+        transaction_id="abc",
+        fraud_score=0.92,
+        risk_level="CRITICAL",
+        transaction_amt=500.0,
+        card_id=12345,
+    )
+    s = a.model_dump_json()
+    parsed = FraudAlert.model_validate_json(s)
+    assert parsed.fraud_score == pytest.approx(0.92)
+    assert parsed.risk_level == "CRITICAL"
+    assert isinstance(parsed.timestamp, datetime)
+
+
+def test_health_status_defaults():
+    h = HealthStatus()
+    assert h.status == "ok"
+    assert h.uptime_seconds == 0.0
+
+
+def test_model_info_excludes_protected_namespaces():
+    """ModelInfoResponse uses ``protected_namespaces=()`` so ``model_*`` fields work."""
+    info = ModelInfoResponse(
+        model_version="vX",
+        n_parameters=1,
+        embedding_dim=64,
+        n_features=10,
+        feature_columns=["a", "b"],
+        edge_types=["x"],
+        node_types=["y"],
+    )
+    assert info.model_version == "vX"

--- a/tests/unit/test_serving_app.py
+++ b/tests/unit/test_serving_app.py
@@ -1,0 +1,313 @@
+"""Integration tests for the FastAPI app using TestClient.
+
+We don't bring up Redis/Kafka -- the app's graceful fallbacks let the
+endpoints run end-to-end with a mock predictor + in-memory streaming.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fraud_detection.serving.app import AppState, create_app
+from fraud_detection.serving.redis_cache import EmbeddingCache
+from fraud_detection.serving.schemas import (
+    BatchPredictResponse,
+    FraudPrediction,
+    HealthStatus,
+    ModelInfoResponse,
+    TransactionRequest,
+    risk_level,
+)
+
+
+class _StubPredictor:
+    """A minimal fake predictor to avoid loading a real model.
+
+    Score is a deterministic function of `transaction_amt` so we can
+    push individual requests above / below the alert threshold at will.
+    """
+
+    threshold = 0.7
+    model_version = "v0.4.0-test"
+    embedding_dim = 0
+    feature_columns: ClassVar[list[str]] = []
+
+    def __init__(self) -> None:
+        # Stub objects to satisfy the model_info endpoint.
+        self.cache = EmbeddingCache(url=None)
+        self.cache.connect()
+        self.ensemble = MagicMock()
+        self.ensemble.gnn = MagicMock()
+        self.ensemble.gnn.n_parameters.return_value = 1234
+        self.ensemble.gnn.embedding_dim = 64
+        self.ensemble.gnn.edge_types = [("transaction", "uses_card", "card")]
+        self.ensemble.gnn.node_types = ["transaction", "card"]
+        self.ensemble.xgb.feature_importance.return_value = {
+            "gnn_emb_000": 0.5,
+            "TransactionAmt": 0.3,
+        }
+
+    def _score(self, amt: float) -> float:
+        # Map any amount > 100 to a fraud score >= 0.7 (alert threshold);
+        # anything below stays below.
+        if amt >= 100:
+            return min(0.99, 0.5 + amt / 1000.0)
+        return max(0.01, amt / 200.0)
+
+    def predict_one(self, req: TransactionRequest) -> FraudPrediction:
+        score = self._score(req.transaction_amt)
+        return FraudPrediction(
+            transaction_id=req.transaction_id,
+            fraud_probability=score,
+            fraud_score=score,
+            risk_level=risk_level(score),
+            is_fraud_predicted=score >= self.threshold,
+            threshold=self.threshold,
+            top_features=[],
+            latency_ms={"total_ms": 0.5},
+            model_version=self.model_version,
+        )
+
+    def predict_batch(self, reqs):
+        return [self.predict_one(r) for r in reqs]
+
+    def info(self) -> dict[str, Any]:
+        return {"model_version": self.model_version}
+
+
+@pytest.fixture
+def app_with_stub_predictor(monkeypatch):
+    """Start the app and replace the lifespan-provisioned predictor with a stub.
+
+    Points the lifespan at a non-existent ensemble dir to skip the (~10s)
+    real-model load. Producer + consumer are kept as the lifespan-provisioned
+    in-memory instances so the running consume_async task sees the same
+    queue our predict endpoint writes to.
+    """
+    monkeypatch.setenv("FRAUD_ENSEMBLE_DIR", "/nonexistent/path/skip-load")
+    # Tighten the consumer poll so WS tests don't hang waiting on the loop.
+    monkeypatch.setenv("FRAUD_TEST_FAST", "true")
+    app = create_app()
+
+    with TestClient(app) as client:
+        state: AppState = app.state.fraud_app
+        # No model was loaded -- substitute the stub.
+        state.predictor = _StubPredictor()  # type: ignore[assignment]
+        # Keep state.producer / state.consumer as the lifespan provisioned them
+        # so the consume_async task fans out to the broadcaster correctly.
+        # Tighten the consumer's poll cadence for the WS test.
+        if state.consumer is not None:
+            state.consumer.poll_timeout_seconds = 0.05
+        yield client, state
+
+
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+
+def test_health_when_model_loaded(app_with_stub_predictor):
+    client, _ = app_with_stub_predictor
+    r = client.get("/api/v1/health")
+    assert r.status_code == 200
+    body = HealthStatus.model_validate(r.json())
+    assert body.status == "ok"
+    assert body.model_loaded
+    assert body.uptime_seconds >= 0
+
+
+def test_health_degraded_when_model_missing(monkeypatch):
+    """Without a stub predictor the lifespan still starts but model_loaded is False."""
+    monkeypatch.setenv("FRAUD_ENSEMBLE_DIR", "/nonexistent/path/skip-load")
+    app = create_app()
+    with TestClient(app) as client:
+        r = client.get("/api/v1/health")
+        assert r.status_code == 200
+        body = HealthStatus.model_validate(r.json())
+        # No model loaded -> degraded
+        assert body.status == "degraded"
+        assert not body.model_loaded
+
+
+# ---------------------------------------------------------------------------
+# Predict (single)
+# ---------------------------------------------------------------------------
+
+
+def test_predict_below_threshold_no_alert(app_with_stub_predictor):
+    client, state = app_with_stub_predictor
+    payload = {"transaction_id": 1, "transaction_dt": 100, "transaction_amt": 25.0}
+    r = client.post("/api/v1/predict", json=payload)
+    assert r.status_code == 200
+    body = FraudPrediction.model_validate(r.json())
+    assert body.transaction_id == 1
+    assert not body.is_fraud_predicted
+    assert body.risk_level == "LOW"
+    # No alert was published because score < threshold
+    assert len(state.producer.drain_in_memory()) == 0
+
+
+def test_predict_above_threshold_publishes_alert(app_with_stub_predictor):
+    client, state = app_with_stub_predictor
+    payload = {"transaction_id": 99, "transaction_dt": 100, "transaction_amt": 500.0}
+    r = client.post("/api/v1/predict", json=payload)
+    assert r.status_code == 200
+    body = FraudPrediction.model_validate(r.json())
+    assert body.is_fraud_predicted
+    assert body.risk_level in ("HIGH", "CRITICAL")
+    # Alert was published to in-memory producer
+    drained = state.producer.drain_in_memory()
+    assert len(drained) == 1
+    assert drained[0].transaction_id == 99
+
+
+def test_predict_validates_payload(app_with_stub_predictor):
+    client, _ = app_with_stub_predictor
+    r = client.post("/api/v1/predict", json={"transaction_id": 1})  # missing fields
+    assert r.status_code == 422  # Pydantic validation error
+
+
+def test_predict_503_when_no_model(monkeypatch):
+    """If predictor is None, /predict returns 503."""
+    monkeypatch.setenv("FRAUD_ENSEMBLE_DIR", "/nonexistent/path/skip-load")
+    app = create_app()
+    with TestClient(app) as client:
+        state: AppState = app.state.fraud_app
+        state.predictor = None  # force unloaded
+        r = client.post(
+            "/api/v1/predict",
+            json={"transaction_id": 1, "transaction_dt": 1, "transaction_amt": 10.0},
+        )
+        assert r.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Predict (batch)
+# ---------------------------------------------------------------------------
+
+
+def test_predict_batch(app_with_stub_predictor):
+    client, _ = app_with_stub_predictor
+    txs = [
+        {"transaction_id": i, "transaction_dt": i, "transaction_amt": 10.0 + i * 100}
+        for i in range(5)
+    ]
+    r = client.post("/api/v1/predict/batch", json={"transactions": txs})
+    assert r.status_code == 200
+    body = BatchPredictResponse.model_validate(r.json())
+    assert body.n_processed == 5
+    assert body.n_alerts >= 1  # at least the higher-amount ones
+    assert body.elapsed_ms >= 0
+
+
+def test_predict_batch_validates_max_size(app_with_stub_predictor):
+    client, _ = app_with_stub_predictor
+    txs = [{"transaction_id": i, "transaction_dt": i, "transaction_amt": 10.0} for i in range(101)]
+    r = client.post("/api/v1/predict/batch", json={"transactions": txs})
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Model info
+# ---------------------------------------------------------------------------
+
+
+def test_model_info(app_with_stub_predictor):
+    client, _ = app_with_stub_predictor
+    r = client.get("/api/v1/model/info")
+    assert r.status_code == 200
+    body = ModelInfoResponse.model_validate(r.json())
+    assert body.n_parameters == 1234
+    assert "uses_card" in body.edge_types[0]
+    assert "transaction" in body.node_types
+    assert body.feature_importance_top_k
+
+
+def test_model_info_503_when_no_model(monkeypatch):
+    monkeypatch.setenv("FRAUD_ENSEMBLE_DIR", "/nonexistent/path/skip-load")
+    app = create_app()
+    with TestClient(app) as client:
+        state: AppState = app.state.fraud_app
+        state.predictor = None
+        r = client.get("/api/v1/model/info")
+        assert r.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Prometheus metrics
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_endpoint_returns_prometheus_text(app_with_stub_predictor):
+    client, _ = app_with_stub_predictor
+    # Make a request to populate counters
+    client.get("/api/v1/health")
+    r = client.get("/api/v1/metrics")
+    assert r.status_code == 200
+    body = r.text
+    # We expect at least one of our custom metrics to show up.
+    assert "meshwatch_http_requests_total" in body or "meshwatch_http_request_latency" in body
+
+
+# ---------------------------------------------------------------------------
+# Root convenience route
+# ---------------------------------------------------------------------------
+
+
+def test_root(app_with_stub_predictor):
+    client, _ = app_with_stub_predictor
+    r = client.get("/")
+    assert r.status_code == 200
+    j = r.json()
+    assert j["service"] == "meshwatch"
+
+
+# ---------------------------------------------------------------------------
+# Middleware (X-Request-ID + X-Response-Time-MS)
+# ---------------------------------------------------------------------------
+
+
+def test_request_id_header_set(app_with_stub_predictor):
+    client, _ = app_with_stub_predictor
+    r = client.get("/api/v1/health")
+    assert "x-request-id" in r.headers
+    assert "x-response-time-ms" in r.headers
+    assert float(r.headers["x-response-time-ms"]) >= 0
+
+
+def test_request_id_passes_through(app_with_stub_predictor):
+    client, _ = app_with_stub_predictor
+    r = client.get("/api/v1/health", headers={"x-request-id": "test-12345"})
+    assert r.headers["x-request-id"] == "test-12345"
+
+
+# ---------------------------------------------------------------------------
+# WebSocket /ws/alerts
+# ---------------------------------------------------------------------------
+
+
+def test_websocket_receives_alert(app_with_stub_predictor):
+    """End-to-end WS path: high-score POST -> producer -> consumer -> broadcaster -> ws.
+
+    The full pipeline is async; we POST a transaction whose score crosses
+    the alert threshold and then wait for the WS message. The
+    in-memory consumer drains every ~1s by default, but we drop the
+    poll interval so the test stays fast.
+    """
+    client, state = app_with_stub_predictor
+    state.consumer.poll_timeout_seconds = 0.05  # tighten poll loop for the test
+    with client.websocket_connect("/ws/alerts") as ws:
+        assert state.broadcaster.n_clients == 1
+        # Score = 0.99 (transaction_amt 500 -> stub_score = min(0.99, 0.5 + 0.5))
+        r = client.post(
+            "/api/v1/predict",
+            json={"transaction_id": "ws-1", "transaction_dt": 1, "transaction_amt": 500.0},
+        )
+        assert r.status_code == 200
+        msg = ws.receive_json()
+        assert msg["transaction_id"] == "ws-1"
+        assert msg["risk_level"] in ("HIGH", "CRITICAL")


### PR DESCRIPTION
End-to-end FastAPI + Kafka + WebSocket + (optional) Ray Serve infrastructure for low-latency fraud-detection inference. Hits 1.6 ms P95 in-process and 19.9 ms P95 over the wire -- both an order of magnitude under the 50 ms plan budget.

Schemas (serving/schemas.py)
* TransactionRequest with extra="allow" + alias support for IEEE-CIS field names (P_emaildomain, R_emaildomain, DeviceType, DeviceInfo)
* FraudPrediction / BatchPredictResponse with per-stage latency_ms
* FraudAlert (Kafka + WebSocket payload), HealthStatus, ModelInfoResponse
* risk_level() bucketer + ALERT_THRESHOLD constant

Embedding cache (serving/redis_cache.py)
* EmbeddingCache: Redis-backed with thread-safe in-memory fallback, TTL, bulk warm_up, and scan-iter clear (only own keys, never the DB)

Predictor (serving/predictor.py)
* FraudPredictor orchestrates: cache lookup -> tabular row -> XGBoost -> SHAP. Lazy SHAP setup so missing dep degrades gracefully
* predict_one + predict_batch emit per-stage latency_ms breakdowns
* load_predictor() helper for the FastAPI lifespan

Middleware (serving/middleware.py)
* RequestTimingMiddleware adds X-Request-ID + X-Response-Time-MS headers
* _MetricsRegistry wraps prometheus_client; falls back to no-op stubs when prometheus-client isn't installed

FastAPI app (serving/app.py)
* 5 REST endpoints: predict, predict/batch, health, model/info, metrics
* WS /ws/alerts with AlertBroadcaster fan-out
* Lifespan loads model, connects Redis + Kafka, starts an async consumer task that drains the topic into the broadcaster
* Every dependency missing -> degraded mode but app stays up

Ray Serve (serving/ray_deployment.py)
* Optional via `python scripts/serve.py --ray --num-replicas 2`
* Wraps the FastAPI app in @serve.ingress + @serve.deployment

Streaming (streaming/kafka_producer.py + kafka_consumer.py)
* FraudAlertProducer: confluent_kafka with deque-backed in-memory fallback
* FraudAlertConsumer: blocking poll on a daemon thread + async consume_async() for the FastAPI lifespan
* Both fall back to in-memory mode when no broker -- tests + local dev work without docker-compose
* Tracked task set so loop.create_task results aren't GC'd mid-flight

CLIs (scripts/)
* serve.py: uvicorn launcher with --ray flag
* demo_stream.py: replay rows from features.parquet to /predict at configurable RPS, print P50/P95/P99 latency summary

Infrastructure (Phase 4 plan, page 9)
* docker-compose.yml: Redis 7 + Kafka 7.6 + Zookeeper + MLflow + Prometheus + Grafana + custom API container, with healthchecks
* Dockerfile.serving: multi-stage Python 3.11 build w/ CPU-only torch wheel + librdkafka1; healthcheck via /api/v1/health
* configs/serve.yaml: documents env-var settings + latency budget
* configs/prometheus.yml: scrapes /api/v1/metrics every 5s

Tests (62 new, 215 total passing at 82% coverage)
* test_schemas (16): Pydantic round-trips, validation, alias handling, batch size limits, risk_level buckets
* test_redis_cache (12): in-memory + Redis fallback, TTL, warm_up, dim mismatch, dead Redis
* test_kafka_streaming (12): producer publish + drain, consumer decode + async dispatch, schema validation
* test_predictor (7): cache hit / cold card / batch ordering / latency breakdown / info
* test_serving_app (15): FastAPI TestClient hits every endpoint including WebSocket alert fan-out (full pipeline: POST /predict -> producer -> consumer -> broadcaster -> WS client)

Latency benchmarks
* In-process predict_one P95: 1.6 ms (cold cache, no SHAP)
* In-process predict_one P95: 1.2 ms (cache hit)
* In-process predict_batch (B=100): 5.2 ms total, ~0.05 ms/row
* Over-the-wire predict P95: 19.9 ms (200 reqs)
* Over-the-wire predict/batch P95: 23.8 ms (50 batches of 20)

Acceptance criteria (per plan, page 9)
[x] docker compose up starts all services (compose w/ healthchecks) [x] API returns valid predictions with correct schema (15 integration tests) [x] P95 latency < 50 ms (measured 1.6 ms in-process / 19.9 ms over the wire) [x] Kafka consumer processes test transactions
[x] WebSocket streams alerts in real time

Other touches
* Makefile: serve, serve-ray, serve-dev, demo-stream, demo-stream-batch, compose-up, compose-down, compose-logs, docker-build-serving, tag-phase-4 (43 targets total)
* README: Phase 4 section w/ topology diagram, latency table, acceptance criteria; phase badge 3/8 -> 4/8; tests badge 153 -> 215; added Latency badge (P95 1.6ms)
* .github/workflows/ci.yml: install [dev,train,serve] (was [dev,train]) so Phase 4 tests can import ray, confluent_kafka, shap, prometheus_client