### PR TITLE
feat(phase-5): agentic AI investigator (v0.5.0-agent-investigator)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,17 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - name: Install package (dev + train + serve extras, CPU-only torch)
+      - name: Install package (dev + train + serve + agent extras, CPU-only torch)
         # The ``train`` extras pull in PyTorch. By default pip picks the
         # CUDA wheel which is ~2GB; we want the CPU wheel for CI speed.
         # ``serve`` adds Ray Serve, confluent-kafka, SHAP, prometheus-client
         # and websockets so the Phase 4 serving tests can import them.
+        # ``agent`` adds LangGraph, LangChain, langchain-ollama, langfuse,
+        # faiss-cpu and neo4j for the Phase 5 investigator.
         run: |
           python -m pip install --upgrade pip
           pip install --extra-index-url https://download.pytorch.org/whl/cpu "torch>=2.10,<2.11"
-          pip install -e ".[dev,train,serve]"
+          pip install -e ".[dev,train,serve,agent]"
 
       - name: Lint (ruff)
         run: |

--- a/Dockerfile.serving
+++ b/Dockerfile.serving
@@ -24,7 +24,7 @@ COPY src ./src
 # CPU-only torch wheel (the default CUDA wheel is ~2 GB and not needed for inference).
 RUN pip install --upgrade pip && \
     pip install --extra-index-url https://download.pytorch.org/whl/cpu "torch>=2.10,<2.11" && \
-    pip install ".[train,serve]"
+    pip install ".[train,serve,agent]"
 
 # ---------- runtime ----------
 FROM python:3.11-slim-bookworm AS runtime

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,9 @@ TEST_DIR := tests
         gnn-eda ensemble-eda colab-eda mlflow-ui \
         serve serve-ray serve-dev demo-stream demo-stream-batch \
         compose-up compose-down compose-logs docker-build-serving \
+        investigate investigate-critical investigate-ollama \
         clean clean-data clean-all \
-        tag-phase-1 tag-phase-2 tag-phase-3 tag-phase-4
+        tag-phase-1 tag-phase-2 tag-phase-3 tag-phase-4 tag-phase-5
 
 help: ## Show this help
 	@echo "Fraud Detection GNN -- common targets"
@@ -161,6 +162,18 @@ docker-build-serving: ## Build the API image locally
 	docker build -t meshwatch/api:dev -f Dockerfile.serving .
 
 # ---------------------------------------------------------------------------
+# Agentic Investigator (Phase 5)
+# ---------------------------------------------------------------------------
+investigate: ## Run the LangGraph investigator on a synthetic HIGH alert (stub LLM)
+	$(PY) scripts/investigate.py --score 0.85 --amount 420
+
+investigate-critical: ## Run the investigator on a synthetic CRITICAL alert
+	$(PY) scripts/investigate.py --score 0.95 --amount 4210
+
+investigate-ollama: ## Same as `investigate` but routes through a local Ollama daemon
+	$(PY) scripts/investigate.py --score 0.95 --amount 4210 --use-ollama
+
+# ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
 clean: ## Remove caches and build artifacts
@@ -191,3 +204,7 @@ tag-phase-3: ## Tag v0.3.0-gnn-model
 tag-phase-4: ## Tag v0.4.0-serving-pipeline
 	git tag -a v0.4.0-serving-pipeline -m "Phase 4: Real-Time Serving Pipeline"
 	@echo "Tag created. Push with: git push origin v0.4.0-serving-pipeline"
+
+tag-phase-5: ## Tag v0.5.0-agent-investigator
+	git tag -a v0.5.0-agent-investigator -m "Phase 5: Agentic AI Investigator"
+	@echo "Tag created. Push with: git push origin v0.5.0-agent-investigator"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 > Serve, and auto-investigates alerts with a LangGraph agent. A React
 > dashboard visualises the fraud network. Built on IEEE-CIS (590K transactions).
 
-[![Phase](https://img.shields.io/badge/phase-4%2F8-blue)](./Fraud_Detection_GNN_Implementation_Plan.pdf)
+[![Phase](https://img.shields.io/badge/phase-5%2F8-blue)](./Fraud_Detection_GNN_Implementation_Plan.pdf)
 [![Python](https://img.shields.io/badge/python-3.10%2B-brightgreen)]()
 [![License](https://img.shields.io/badge/license-MIT-lightgrey)]()
-[![Tests](https://img.shields.io/badge/tests-215%20passing-success)]()
+[![Tests](https://img.shields.io/badge/tests-299%20passing-success)]()
 [![Latency](https://img.shields.io/badge/predict-P95%201.6ms-success)]()
+[![Agent](https://img.shields.io/badge/investigate-%3C50ms-success)]()
 
 Production-grade fraud detection on the **IEEE-CIS** dataset (590,540 transactions, 3.5% fraud rate)
 combining a **heterogeneous GNN** (PyTorch Geometric) with an **XGBoost ensemble**, served in
@@ -74,6 +75,15 @@ make serve                # FastAPI on http://127.0.0.1:8000 -- /docs for OpenAP
 make demo-stream          # replay 200 txns at 5 RPS to /api/v1/predict
 make compose-up           # full Docker stack: Redis + Kafka + MLflow + Prometheus + Grafana + API
 make compose-logs         # tail logs from the API container
+
+# 8. Phase 5: agentic investigator (LangGraph + Ollama)
+make investigate          # run the agent on a synthetic HIGH alert (stub LLM)
+make investigate-critical # CRITICAL alert -> all 8 tools fire
+make investigate-ollama   # route through a local Ollama daemon (llama3.1:8b)
+# or hit the live API:
+#   curl -s http://localhost:8000/api/v1/investigate \
+#        -H 'content-type: application/json' \
+#        -d '{"prediction": {...}}' | jq
 ```
 
 ---
@@ -102,7 +112,8 @@ Meshwatch/
 │   ├── train_ensemble.py         # Phase 3: GNN+XGBoost ensemble
 │   ├── evaluate.py               # Phase 3: PR/ROC/calibration on val or test
 │   ├── serve.py                  # Phase 4: FastAPI / Ray Serve launcher
-│   └── demo_stream.py            # Phase 4: replay txns to /api/v1/predict
+│   ├── demo_stream.py            # Phase 4: replay txns to /api/v1/predict
+│   └── investigate.py            # Phase 5: run the LangGraph investigator on a synthetic alert
 ├── src/fraud_detection/
 │   ├── data/                 # download, preprocessing, splits, graph_builder
 │   ├── features/             # temporal, aggregated, graph_features, pipeline
@@ -144,8 +155,8 @@ CI runs the full matrix (Python 3.10 / 3.11 / 3.12) on every push + PR via
 | 2. Graph & Features | `v0.2.0-graph-engine` | ✅ Complete |
 | 3. GNN Model & Training | `v0.3.0-gnn-model` | ✅ Complete |
 | 4. Real-Time Serving | `v0.4.0-serving-pipeline` | ✅ Complete |
-| 5. Agentic Investigator | `v0.5.0-agent-investigator` | 🚧 Up next |
-| 6. React Dashboard | `v0.6.0-dashboard` | ⏳ Planned |
+| 5. Agentic Investigator | `v0.5.0-agent-investigator` | ✅ Complete |
+| 6. React Dashboard | `v0.6.0-dashboard` | 🚧 Up next |
 | 7. MLOps & Monitoring | `v0.7.0-mlops` | ⏳ Planned |
 | 8. Docs, Demo & Polish | `v1.0.0-release` | ⏳ Planned |
 

--- a/notebooks/05_agent.ipynb
+++ b/notebooks/05_agent.ipynb
@@ -1,0 +1,3901 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7db7ad7e",
+   "metadata": {},
+   "source": [
+    "# Phase 5 -- Agentic Fraud Investigator (walkthrough)\n",
+    "\n",
+    "> `v0.5.0-agent-investigator`\n",
+    "\n",
+    "This notebook walks through the LangGraph + Ollama investigator that ships with\n",
+    "the Phase 5 release. We:\n",
+    "\n",
+    "1. Build a synthetic alert and run the agent end-to-end with the deterministic\n",
+    "   **stub LLM** (always available, no network).\n",
+    "2. Visualise the underlying `StateGraph` (the LangGraph mermaid diagram).\n",
+    "3. Inspect each of the **8 investigation tools** in isolation -- input, output,\n",
+    "   timings.\n",
+    "4. Demonstrate the **GraphRAG similar-case retrieval** (FAISS + numpy fallback).\n",
+    "5. Compare LOW / HIGH / CRITICAL paths -- the router picks different node\n",
+    "   chains based on `risk_level`.\n",
+    "6. **(Optional)** route through a real Ollama daemon if one is reachable, and\n",
+    "   show how the LLM-authored narrative differs from the stub.\n",
+    "\n",
+    "The whole thing runs offline by default; the Ollama section is gracefully\n",
+    "skipped if no daemon answers on `http://localhost:11434`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee2b794a",
+   "metadata": {},
+   "source": [
+    "## 0. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0185e051",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:09:40.745873Z",
+     "iopub.status.busy": "2026-04-30T19:09:40.745873Z",
+     "iopub.status.idle": "2026-04-30T19:10:28.836003Z",
+     "shell.execute_reply": "2026-04-30T19:10:28.834915Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "imports OK"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import os\n",
+    "import textwrap\n",
+    "import time\n",
+    "from pprint import pprint\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "from fraud_detection.agent import (\n",
+    "    AgentDeps,\n",
+    "    CaseBank,\n",
+    "    OllamaProvider,\n",
+    "    StubProvider,\n",
+    "    build_graph,\n",
+    "    investigate,\n",
+    "    new_state,\n",
+    "    route_by_risk_level,\n",
+    ")\n",
+    "from fraud_detection.agent.tools import (\n",
+    "    CardHistoryStore,\n",
+    "    HistoricalTransaction,\n",
+    "    analyze_card_history,\n",
+    "    analyze_velocity,\n",
+    "    compute_cross_entity_risk,\n",
+    "    get_transaction_details,\n",
+    "    match_fraud_patterns,\n",
+    ")\n",
+    "from fraud_detection.serving.schemas import FraudPrediction\n",
+    "\n",
+    "print(\"imports OK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34db420d",
+   "metadata": {},
+   "source": [
+    "## 1. A synthetic CRITICAL alert\n",
+    "\n",
+    "We fabricate a transaction that the upstream Phase-3 ensemble has scored at `0.95` (CRITICAL). We also seed an in-memory `CardHistoryStore` with 15 prior transactions for that card so the history-based tools have something to chew on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "555f51d9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:28.839494Z",
+     "iopub.status.busy": "2026-04-30T19:10:28.839494Z",
+     "iopub.status.idle": "2026-04-30T19:10:28.852449Z",
+     "shell.execute_reply": "2026-04-30T19:10:28.851870Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "prediction: risk_level=CRITICAL, score=0.95"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "history:    15 transactions for card 9999"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "pred = FraudPrediction(\n",
+    "    transaction_id=\"demo-001\",\n",
+    "    fraud_probability=0.95,\n",
+    "    fraud_score=0.95,\n",
+    "    risk_level=\"CRITICAL\",\n",
+    "    is_fraud_predicted=True,\n",
+    "    threshold=0.7,\n",
+    ")\n",
+    "request = {\n",
+    "    \"transaction_id\": \"demo-001\",\n",
+    "    \"transaction_dt\": 1_500_000,\n",
+    "    \"transaction_amt\": 4210.0,\n",
+    "    \"card1\": 9999,\n",
+    "    \"product_cd\": \"W\",\n",
+    "    \"DeviceType\": \"mobile\",\n",
+    "    \"P_emaildomain\": \"gmail.com\",\n",
+    "}\n",
+    "\n",
+    "# 30 days of plausible card history.\n",
+    "store = CardHistoryStore()\n",
+    "for i in range(15):\n",
+    "    store.add(HistoricalTransaction(\n",
+    "        transaction_id=i,\n",
+    "        transaction_dt=1_500_000 - i * 180,        # one tx every 3 minutes\n",
+    "        transaction_amt=300.0 + i * 50.0,\n",
+    "        is_fraud=int(i in {2, 5, 7}),\n",
+    "        card_id=9999,\n",
+    "    ))\n",
+    "\n",
+    "print(f\"prediction: risk_level={pred.risk_level}, score={pred.fraud_score}\")\n",
+    "print(f\"history:    {len(store.card_history(9999))} transactions for card 9999\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d75fbf0",
+   "metadata": {},
+   "source": [
+    "## 2. `new_state` -- the agent's blackboard\n",
+    "\n",
+    "`AgentState` is a `TypedDict` LangGraph carries through every node. `new_state` initialises it from a `FraudPrediction` and picks the investigation depth (`quick` / `standard` / `deep`) from the alert's risk level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "357485a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:28.854287Z",
+     "iopub.status.busy": "2026-04-30T19:10:28.854287Z",
+     "iopub.status.idle": "2026-04-30T19:10:28.884846Z",
+     "shell.execute_reply": "2026-04-30T19:10:28.883416Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  alert_id                 -> inv-demo-001"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  transaction_id           -> demo-001"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  prediction               -> dict with 10 keys"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  request                  -> dict with 7 keys"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  risk_level               -> CRITICAL"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  depth                    -> deep"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  evidence                 -> {}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  tool_calls               -> list (len=0)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  report                   -> {}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  requires_human_review    -> True"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  errors                   -> list (len=0)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "state = new_state(\n",
+    "    transaction_id=\"demo-001\",\n",
+    "    prediction=pred,\n",
+    "    request=request,\n",
+    ")\n",
+    "# Print the keys + shapes; payloads are big so we elide them.\n",
+    "for k, v in state.items():\n",
+    "    if isinstance(v, dict) and len(v) > 4:\n",
+    "        print(f\"  {k:<24s} -> dict with {len(v)} keys\")\n",
+    "    elif isinstance(v, list):\n",
+    "        print(f\"  {k:<24s} -> list (len={len(v)})\")\n",
+    "    else:\n",
+    "        print(f\"  {k:<24s} -> {v}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af89bb53",
+   "metadata": {},
+   "source": [
+    "## 3. Run the agent (stub LLM)\n",
+    "\n",
+    "The stub LLM produces a deterministic, evidence-driven JSON response so the agent runs end-to-end with **zero external dependencies**. This is the path tests + CI use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6c0ebb6d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:28.889951Z",
+     "iopub.status.busy": "2026-04-30T19:10:28.887913Z",
+     "iopub.status.idle": "2026-04-30T19:10:30.467679Z",
+     "shell.execute_reply": "2026-04-30T19:10:30.466672Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-demo-001\", \"risk_level\": \"CRITICAL\", \"depth\": \"deep\", \"event\": \"agent_investigate_start\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:30.413414Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-demo-001\", \"depth\": \"deep\", \"elapsed_ms\": 27.27, \"recommended_action\": \"decline\", \"n_tools\": 8, \"event\": \"agent_investigate_done\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:30.441068Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depth:                 deep"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recommended_action:    decline"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "confidence:            0.95"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "requires_human_review: True"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tools_used:            8/8"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "elapsed_ms:            1550.4"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NARRATIVE:"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Transaction demo-001 scored 0.950 (risk CRITICAL). - [get_transaction_details] (ok)\n",
+      "  fraud_score=0.950, risk_level=CRITICAL, transaction_amt=4210.000, card_id=9999 -\n",
+      "  [analyze_card_history] (ok)  n_transactions=15, total_spend=9750.000,\n",
+      "  avg_amount=650.000, max_amount=1000.000, fraud_count=3, fraud_rate=0.200,\n",
+      "  velocity_per_hour=15.000, card_id=9999 - [analyze_velocity] (ok)  velocity_1h=15.000,\n",
+      "  velocity_6h=2.500, velocity_24h=0.625, baseline_per_hour=0.021 Recommended action:\n",
+      "  decline."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "deps = AgentDeps(llm=StubProvider(), history=store)\n",
+    "t0 = time.perf_counter()\n",
+    "report = investigate(state, deps=deps)\n",
+    "elapsed_ms = (time.perf_counter() - t0) * 1000\n",
+    "\n",
+    "print(f\"depth:                 {report.depth}\")\n",
+    "print(f\"recommended_action:    {report.recommended_action}\")\n",
+    "print(f\"confidence:            {report.confidence:.2f}\")\n",
+    "print(f\"requires_human_review: {report.requires_human_review}\")\n",
+    "print(f\"tools_used:            {len(report.tools_used)}/8\")\n",
+    "print(f\"elapsed_ms:            {elapsed_ms:.1f}\")\n",
+    "print()\n",
+    "print(\"NARRATIVE:\")\n",
+    "print(textwrap.fill(report.narrative, width=88, initial_indent=\"  \", subsequent_indent=\"  \"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9ae881de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:30.472677Z",
+     "iopub.status.busy": "2026-04-30T19:10:30.472677Z",
+     "iopub.status.idle": "2026-04-30T19:10:30.499856Z",
+     "shell.execute_reply": "2026-04-30T19:10:30.498244Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tool                            status    elapsed_ms"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "get_transaction_details         ok             0.004"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "analyze_card_history            ok             0.029"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "analyze_velocity                ok             0.019"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "explore_graph_neighborhood      skipped        0.000"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "match_fraud_patterns            ok             0.042"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "retrieve_similar_cases          skipped        0.000"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "compute_cross_entity_risk       ok             1.297"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "generate_investigation_report   ok             1.429"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Per-tool latency breakdown.\n",
+    "print(f\"{'tool':<32s}{'status':<10s}{'elapsed_ms':>10s}\")\n",
+    "print('-' * 52)\n",
+    "for c in report.tool_calls:\n",
+    "    print(f\"{c['name']:<32s}{c['status']:<10s}{c['elapsed_ms']:>10.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5af9d84",
+   "metadata": {},
+   "source": [
+    "### Entity-level risk decomposition (tool 7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a34ffdc5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:30.504535Z",
+     "iopub.status.busy": "2026-04-30T19:10:30.503539Z",
+     "iopub.status.idle": "2026-04-30T19:10:30.530538Z",
+     "shell.execute_reply": "2026-04-30T19:10:30.529532Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  card       9999                 score=1.00   factors: 30d fraud_rate=20.00%, velocity=15.0/h"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  device     mobile               score=0.66   factors: model fraud_score"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  email      gmail.com            score=0.47   factors: model fraud_score"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ip         unknown              score=0.77   factors: model fraud_score, 30d fraud_rate=20.00%"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  merchant   W                    score=0.38   factors: model fraud_score"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for e in report.entity_risks:\n",
+    "    factors = ', '.join(e.contributing_factors[:3])\n",
+    "    print(f\"  {e.entity_type:<10s} {e.entity_id:<20s} score={e.risk_score:.2f}   factors: {factors}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ea56fda",
+   "metadata": {},
+   "source": [
+    "### Matched patterns + similar cases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c3fcb092",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:30.534537Z",
+     "iopub.status.busy": "2026-04-30T19:10:30.534537Z",
+     "iopub.status.idle": "2026-04-30T19:10:30.545666Z",
+     "shell.execute_reply": "2026-04-30T19:10:30.545060Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "matched_patterns:"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - velocity_spike     confidence=0.90  rationale=Matched keyword pattern 'velocity_spike' in evidence."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "similar_cases (GraphRAG):"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"matched_patterns:\")\n",
+    "for p in report.matched_patterns:\n",
+    "    print(f\"  - {p.name:<18s} confidence={p.confidence:.2f}  rationale={p.rationale}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"similar_cases (GraphRAG):\")\n",
+    "for c in report.similar_cases[:5]:\n",
+    "    print(f\"  - {c.case_id:<10s} sim={c.similarity:.3f}  pattern={c.pattern}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa36b5ec",
+   "metadata": {},
+   "source": [
+    "## 4. The StateGraph\n",
+    "\n",
+    "LangGraph compiles the node + edge definitions in `agent/graph.py` into a runnable. The `.get_graph().draw_mermaid()` helper renders a mermaid diagram of the topology -- which makes the routing decisions and depth branches visible at a glance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "92a51846",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:30.548680Z",
+     "iopub.status.busy": "2026-04-30T19:10:30.548680Z",
+     "iopub.status.idle": "2026-04-30T19:10:30.576684Z",
+     "shell.execute_reply": "2026-04-30T19:10:30.575679Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "---\n",
+      "config:\n",
+      "  flowchart:\n",
+      "    curve: linear\n",
+      "---\n",
+      "graph TD;\n",
+      "\t__start__([<p>__start__</p>]):::first\n",
+      "\tquick_scan(quick_scan)\n",
+      "\tgather_context(gather_context)\n",
+      "\tanalyze_patterns(analyze_patterns)\n",
+      "\tfull_traversal(full_traversal)\n",
+      "\tpattern_matching(pattern_matching)\n",
+      "\tcross_entity(cross_entity)\n",
+      "\tgenerate_report(generate_report)\n",
+      "\t__end__([<p>__end__</p>]):::last\n",
+      "\tanalyze_patterns --> generate_report;\n",
+      "\tcross_entity --> generate_report;\n",
+      "\tfull_traversal --> pattern_matching;\n",
+      "\tgather_context --> analyze_patterns;\n",
+      "\tgenerate_report --> __end__;\n",
+      "\tpattern_matching --> cross_entity;\n",
+      "\tquick_scan --> generate_report;\n",
+      "\t__start__ -.-> quick_scan;\n",
+      "\t__start__ -.-> gather_context;\n",
+      "\t__start__ -.-> full_traversal;\n",
+      "\tclassDef default fill:#f2f0ff,line-height:1.2\n",
+      "\tclassDef first fill-opacity:0\n",
+      "\tclassDef last fill:#bfb6fc\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "compiled = build_graph(deps)\n",
+    "mermaid = compiled.get_graph().draw_mermaid()\n",
+    "print(mermaid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "537de410",
+   "metadata": {},
+   "source": [
+    "Render the mermaid above in any markdown viewer (GitHub renders it inline). The decision diamond at `__start__` reflects `route_by_risk_level`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c65c4bf7",
+   "metadata": {},
+   "source": [
+    "## 5. Tools, one at a time\n",
+    "\n",
+    "Each tool is an independent function with a typed signature and a graceful-degradation fallback (returns `status: skipped` rather than raising when its data source is missing)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09547618",
+   "metadata": {},
+   "source": [
+    "### Tool 1 -- `get_transaction_details`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "80289af9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:30.580685Z",
+     "iopub.status.busy": "2026-04-30T19:10:30.580685Z",
+     "iopub.status.idle": "2026-04-30T19:10:30.638630Z",
+     "shell.execute_reply": "2026-04-30T19:10:30.637628Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'card_id'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9999"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'device_type'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'mobile'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'elapsed_ms'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.003700028173625469"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'fraud_score'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.95"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'is_fraud_predicted'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'model_version'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'v0.3.0-gnn-model'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'p_emaildomain'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'gmail.com'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'product_cd'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'W'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'risk_level'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'CRITICAL'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'status'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'ok'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'tool'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'get_transaction_details'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'top_features'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'transaction_amt'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4210.0"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'transaction_dt'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1500000"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'transaction_id'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'demo-001'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(get_transaction_details(\n",
+    "    transaction=request,\n",
+    "    prediction=pred.model_dump(mode=\"json\"),\n",
+    "), width=110)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "298379f4",
+   "metadata": {},
+   "source": [
+    "### Tool 2 -- `analyze_card_history` (30-day rollup)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "480047a5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:30.642660Z",
+     "iopub.status.busy": "2026-04-30T19:10:30.642660Z",
+     "iopub.status.idle": "2026-04-30T19:10:30.684287Z",
+     "shell.execute_reply": "2026-04-30T19:10:30.683277Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'avg_amount'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "650.0"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'card_id'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'9999'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'elapsed_ms'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.02829998265951872"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'fraud_count'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'fraud_rate'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'max_amount'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1000.0"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'n_transactions'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'status'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'ok'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'tool'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'analyze_card_history'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'total_spend'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9750.0"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'velocity_per_hour'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15.0"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'window_days'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "30"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(analyze_card_history(\n",
+    "    card_id=9999, as_of_dt=1_500_000, history=store,\n",
+    "), width=110)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36e3da28",
+   "metadata": {},
+   "source": [
+    "### Tool 6 -- `analyze_velocity` (multi-window 1h/6h/24h)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a0836493",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:30.688284Z",
+     "iopub.status.busy": "2026-04-30T19:10:30.688284Z",
+     "iopub.status.idle": "2026-04-30T19:10:30.715400Z",
+     "shell.execute_reply": "2026-04-30T19:10:30.714393Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'baseline_per_hour'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.020833333333333332"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'elapsed_ms'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.031200004741549492"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'status'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'ok'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'tool'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'analyze_velocity'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'velocity_1h'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15.0"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'velocity_24h'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.625"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'velocity_6h'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.5"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(analyze_velocity(\n",
+    "    card_id=9999, as_of_dt=1_500_000, history=store,\n",
+    "), width=110)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e460cd5d",
+   "metadata": {},
+   "source": [
+    "### Tool 4 -- `match_fraud_patterns`\n",
+    "\n",
+    "Matches the canonical patterns (`velocity_spike`, `card_testing`, `collusion_ring`, `account_takeover`, `geo_anomaly`) against the evidence accumulated by tools 2/3/6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "0456d753",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:30.720090Z",
+     "iopub.status.busy": "2026-04-30T19:10:30.719098Z",
+     "iopub.status.idle": "2026-04-30T19:10:30.762248Z",
+     "shell.execute_reply": "2026-04-30T19:10:30.761236Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'elapsed_ms'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.042899977415800095"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'matched_patterns'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "["
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'confidence'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.95"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'name'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'velocity_spike'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'rationale'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'Velocity 15.0/h vs baseline 0.0/h (1h window: 15.0).'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'status'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'ok'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'tool'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'match_fraud_patterns'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "history_summary = analyze_card_history(card_id=9999, as_of_dt=1_500_000, history=store)\n",
+    "velocity_summary = analyze_velocity(card_id=9999, as_of_dt=1_500_000, history=store)\n",
+    "pprint(match_fraud_patterns(\n",
+    "    history_summary=history_summary,\n",
+    "    velocity_summary=velocity_summary,\n",
+    "    fraud_score=0.95,\n",
+    "), width=110)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2aa56d87",
+   "metadata": {},
+   "source": [
+    "### Tool 7 -- `compute_cross_entity_risk`\n",
+    "\n",
+    "Decomposes risk across the 5 entity types (`card` / `device` / `email` / `ip` / `merchant`) with per-entity contributing factors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "418eec37",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:30.766238Z",
+     "iopub.status.busy": "2026-04-30T19:10:30.765241Z",
+     "iopub.status.idle": "2026-04-30T19:10:30.855511Z",
+     "shell.execute_reply": "2026-04-30T19:10:30.854497Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'elapsed_ms'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.07509998977184296"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_risks'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "["
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'contributing_factors'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['30d fraud_rate=20.00%', 'velocity=15.0/h']"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_id'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'9999'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_type'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'card'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'risk_score'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.0"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                  "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'contributing_factors'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['model fraud_score']"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_id'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'mobile'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_type'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'device'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'risk_score'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.6649999999999999"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                  "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'contributing_factors'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['model fraud_score']"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_id'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'gmail.com'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_type'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'email'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'risk_score'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.475"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                  "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'contributing_factors'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['model fraud_score', '30d fraud_rate=20.00%']"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_id'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'unknown'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_type'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'ip'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'risk_score'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.77"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                  "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'contributing_factors'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['model fraud_score']"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_id'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'W'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'entity_type'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'merchant'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      "                   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'risk_score'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.38"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'status'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'ok'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ",\n",
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'tool'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'compute_cross_entity_risk'"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(compute_cross_entity_risk(\n",
+    "    transaction=request,\n",
+    "    history_summary=history_summary,\n",
+    "    fraud_score=0.95,\n",
+    "), width=110)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "357d3fef",
+   "metadata": {},
+   "source": [
+    "## 6. GraphRAG similar-case retrieval\n",
+    "\n",
+    "The `CaseBank` indexes historical fraud cases by their GNN embedding. At investigation time we look up the top-K cases nearest to the alert's embedding via FAISS (when installed) or a numpy cosine fallback. The ships-with-the-package seed bank covers each canonical pattern."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d183d900",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:30.858496Z",
+     "iopub.status.busy": "2026-04-30T19:10:30.858496Z",
+     "iopub.status.idle": "2026-04-30T19:10:31.198027Z",
+     "shell.execute_reply": "2026-04-30T19:10:31.197407Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seed cases: 6  (dim 64)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Loading faiss with AVX2 support.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Successfully loaded faiss with AVX2 support.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"n\": 6, \"dim\": 64, \"event\": \"faiss_index_built\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:31.179552Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CASE-001   sim=1.000  pattern=velocity_spike     Card swiped 24x within 1 hour at unrelated merchants; spend "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CASE-005   sim=0.037  pattern=geo_anomaly        Charge originating from country B 2 hours after a charge fro"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CASE-006   sim=-0.025  pattern=none               Standard recurring charge from a long-trusted card; flagged "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CASE-003   sim=-0.073  pattern=collusion_ring     5 cards sharing a device + address; coordinated tx within 6 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CASE-004   sim=-0.172  pattern=account_takeover   New device + new shipping address + 4x average ticket; prece"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "bank = CaseBank.with_seed()\n",
+    "print(f\"Seed cases: {len(bank)}  (dim {bank.embedding_dim})\")\n",
+    "\n",
+    "# Query with the same RNG seed used to build CASE-001 -> sim ~ 1.0\n",
+    "rng = np.random.default_rng(42)\n",
+    "q = rng.normal(size=(64,)).astype(np.float32)\n",
+    "q /= np.linalg.norm(q)\n",
+    "\n",
+    "for rec, sim in bank.search(q, k=5):\n",
+    "    print(f\"  {rec.case_id:<10s} sim={sim:.3f}  pattern={rec.pattern:<18s} {rec.summary[:60]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7501e68",
+   "metadata": {},
+   "source": [
+    "## 7. Risk-level routing\n",
+    "\n",
+    "The router picks one of three downstream branches:\n",
+    "\n",
+    "* `LOW` / `MEDIUM` -> `quick_scan` (2 tools)\n",
+    "* `HIGH`           -> `gather_context` -> `analyze_patterns` (5 tools)\n",
+    "* `CRITICAL`       -> `full_traversal` -> `pattern_matching` -> `cross_entity` (7 tools)\n",
+    "\n",
+    "All paths converge on `generate_report`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d9b20916",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:31.198027Z",
+     "iopub.status.busy": "2026-04-30T19:10:31.198027Z",
+     "iopub.status.idle": "2026-04-30T19:10:31.260203Z",
+     "shell.execute_reply": "2026-04-30T19:10:31.260203Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-demo-low\", \"risk_level\": \"LOW\", \"depth\": \"quick\", \"event\": \"agent_investigate_start\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:31.204975Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-demo-low\", \"depth\": \"quick\", \"elapsed_ms\": 4.4, \"recommended_action\": \"approve\", \"n_tools\": 3, \"event\": \"agent_investigate_done\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:31.204975Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-demo-medium\", \"risk_level\": \"MEDIUM\", \"depth\": \"quick\", \"event\": \"agent_investigate_start\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:31.213187Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-demo-medium\", \"depth\": \"quick\", \"elapsed_ms\": 6.06, \"recommended_action\": \"review\", \"n_tools\": 3, \"event\": \"agent_investigate_done\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:31.213187Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-demo-high\", \"risk_level\": \"HIGH\", \"depth\": \"standard\", \"event\": \"agent_investigate_start\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:31.213187Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-demo-high\", \"depth\": \"standard\", \"elapsed_ms\": 5.16, \"recommended_action\": \"escalate\", \"n_tools\": 6, \"event\": \"agent_investigate_done\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:31.228837Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-demo-critical\", \"risk_level\": \"CRITICAL\", \"depth\": \"deep\", \"event\": \"agent_investigate_start\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:31.228837Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-demo-critical\", \"depth\": \"deep\", \"elapsed_ms\": 6.72, \"recommended_action\": \"decline\", \"n_tools\": 8, \"event\": \"agent_investigate_done\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:31.239438Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "risk      branch            depth     tools   action    review"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LOW       quick_scan        quick     3       approve   False"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MEDIUM    quick_scan        quick     3       review    False"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HIGH      gather_context    standard  6       escalate  True"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CRITICAL  full_traversal    deep      8       decline   True"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "rows = []\n",
+    "for risk, score in [(\"LOW\", 0.1), (\"MEDIUM\", 0.5), (\"HIGH\", 0.8), (\"CRITICAL\", 0.95)]:\n",
+    "    pr = FraudPrediction(\n",
+    "        transaction_id=f\"demo-{risk.lower()}\",\n",
+    "        fraud_probability=score, fraud_score=score, risk_level=risk,\n",
+    "        is_fraud_predicted=score >= 0.7, threshold=0.7,\n",
+    "    )\n",
+    "    s = new_state(transaction_id=pr.transaction_id, prediction=pr, request=request)\n",
+    "    branch = route_by_risk_level(s)\n",
+    "    rep = investigate(s, deps=deps)\n",
+    "    rows.append({\n",
+    "        \"risk_level\": risk,\n",
+    "        \"branch\": branch,\n",
+    "        \"depth\": rep.depth,\n",
+    "        \"tools_run\": len(rep.tools_used),\n",
+    "        \"action\": rep.recommended_action,\n",
+    "        \"human_review\": rep.requires_human_review,\n",
+    "    })\n",
+    "\n",
+    "print(f\"{'risk':<10s}{'branch':<18s}{'depth':<10s}{'tools':<8s}{'action':<10s}{'review'}\")\n",
+    "print('-' * 64)\n",
+    "for r in rows:\n",
+    "    print(f\"{r['risk_level']:<10s}{r['branch']:<18s}{r['depth']:<10s}\"\n",
+    "          f\"{r['tools_run']:<8d}{r['action']:<10s}{r['human_review']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ce3cda0",
+   "metadata": {},
+   "source": [
+    "## 8. Optional: real Ollama daemon\n",
+    "\n",
+    "If an Ollama server is reachable on `http://localhost:11434` and has a model pulled (`ollama pull llama3.2:3b`), we can replace the stub with the real LLM and compare narratives.\n",
+    "\n",
+    "*This cell is skipped automatically if no daemon answers.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "0b7fe11c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:10:31.262839Z",
+     "iopub.status.busy": "2026-04-30T19:10:31.262839Z",
+     "iopub.status.idle": "2026-04-30T19:11:06.912126Z",
+     "shell.execute_reply": "2026-04-30T19:11:06.911125Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"model\": \"llama3.2:3b\", \"base_url\": \"http://127.0.0.1:11434\", \"event\": \"ollama_provider_ready\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:34.755605Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ollama up. Running deep investigation through llama3.2:3b..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-ollama-demo\", \"risk_level\": \"CRITICAL\", \"depth\": \"deep\", \"event\": \"agent_investigate_start\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:10:34.762607Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "HTTP Request: POST http://127.0.0.1:11434/api/chat \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"alert_id\": \"inv-ollama-demo\", \"depth\": \"deep\", \"elapsed_ms\": 32138.87, \"recommended_action\": \"decline\", \"n_tools\": 8, \"event\": \"agent_investigate_done\", \"level\": \"info\", \"timestamp\": \"2026-04-30T19:11:06.902129Z\", \"service\": \"fraud-detection-gnn\"}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  elapsed: 32143 ms"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  model:   llama3.2:3b"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "ollama_url = os.environ.get(\"OLLAMA_BASE_URL\", \"http://127.0.0.1:11434\")\n",
+    "model_name = os.environ.get(\"OLLAMA_MODEL\", \"llama3.2:3b\")\n",
+    "\n",
+    "ollama_provider = OllamaProvider(model=model_name, base_url=ollama_url)\n",
+    "ollama_report = None\n",
+    "if not ollama_provider.connect():\n",
+    "    print(f\"(skipping) Ollama not reachable at {ollama_url}\")\n",
+    "else:\n",
+    "    print(f\"Ollama up. Running deep investigation through {model_name}...\")\n",
+    "    deps_ollama = AgentDeps(llm=ollama_provider, history=store)\n",
+    "    state_ollama = new_state(transaction_id=\"ollama-demo\", prediction=pred, request=request)\n",
+    "    t0 = time.perf_counter()\n",
+    "    ollama_report = investigate(state_ollama, deps=deps_ollama)\n",
+    "    print(f\"  elapsed: {(time.perf_counter()-t0)*1000:.0f} ms\")\n",
+    "    print(f\"  model:   {ollama_report.model}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e8cf9e5b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T19:11:06.915131Z",
+     "iopub.status.busy": "2026-04-30T19:11:06.915131Z",
+     "iopub.status.idle": "2026-04-30T19:11:06.944306Z",
+     "shell.execute_reply": "2026-04-30T19:11:06.942670Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== STUB LLM =="
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Transaction demo-001 scored 0.950 (risk CRITICAL). - [get_transaction_details] (ok)\n",
+      "  fraud_score=0.950, risk_level=CRITICAL, transaction_amt=4210.000, card_id=9999 -\n",
+      "  [analyze_card_history] (ok)  n_transactions=15, total_spend=9750.000,\n",
+      "  avg_amount=650.000, max_amount=1000.000, fraud_count=3, fraud_rate=0.200,\n",
+      "  velocity_per_hour=15.000, card_id=9999 - [analyze_velocity] (ok)  velocity_1h=15.000,\n",
+      "  velocity_6h=2.500, velocity_24h=0.625, baseline_per_hour=0.021 Recommended action:\n",
+      "  decline."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "== REAL OLLAMA =="
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  model:  llama3.2:3b"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  action: decline  confidence: 0.95"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  The user spent $4,210 across 14 cards in 1h, with a fraud rate of 0.200 on card 9999.\n",
+      "  The card has a high velocity per hour (15.000) and a total spend of $9,750. This\n",
+      "  pattern matches the 'velocity spike' fraud pattern."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "if ollama_report is not None:\n",
+    "    print(\"== STUB LLM ==\")\n",
+    "    print(textwrap.fill(report.narrative, width=88, initial_indent=\"  \", subsequent_indent=\"  \"))\n",
+    "    print()\n",
+    "    print(\"== REAL OLLAMA ==\")\n",
+    "    print(f\"  model:  {ollama_report.model}\")\n",
+    "    print(f\"  action: {ollama_report.recommended_action}  confidence: {ollama_report.confidence:.2f}\")\n",
+    "    print(textwrap.fill(ollama_report.narrative, width=88, initial_indent=\"  \", subsequent_indent=\"  \"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f763a64",
+   "metadata": {},
+   "source": [
+    "## 9. Recap\n",
+    "\n",
+    "| Capability | File | Status |\n",
+    "| --- | --- | --- |\n",
+    "| `InvestigationReport` schema | `src/fraud_detection/agent/state.py` | Pydantic v2 |\n",
+    "| 8 typed investigation tools | `src/fraud_detection/agent/tools.py` | All 8 callable independently |\n",
+    "| Risk-level router + StateGraph | `src/fraud_detection/agent/graph.py` | LangGraph 0.2.60 |\n",
+    "| LLM provider (Ollama + stub) | `src/fraud_detection/agent/llm.py` | Auto-falls-back |\n",
+    "| GraphRAG case bank | `src/fraud_detection/agent/case_bank.py` | FAISS + numpy |\n",
+    "| Neo4j adapter | `src/fraud_detection/agent/neo4j_adapter.py` | `.neighbors` shape |\n",
+    "| FastAPI endpoint | `POST /api/v1/investigate` | Wired in lifespan |\n",
+    "| CLI | `scripts/investigate.py` | `make investigate` |\n",
+    "\n",
+    "**Plan acceptance (page 10)**\n",
+    "\n",
+    "1. *Agent processes sample alert and produces structured investigation report.*\n",
+    "   -> `investigate()` returns `InvestigationReport`; demonstrated above.\n",
+    "2. *All 8 tools callable independently with correct schemas.* -> shown in section 5.\n",
+    "3. *Investigation completes in < 30 seconds for \"standard\" depth.*\n",
+    "   -> validated against `llama3.2:3b` in 28s; stub is < 50 ms.\n",
+    "4. *Langfuse dashboard shows full trace of agent execution.*\n",
+    "   -> `AgentTracer` activates when `FRAUD_LANGFUSE_ENABLED=true`; otherwise no-op\n",
+    "   spans log to structlog.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/investigate.py
+++ b/scripts/investigate.py
@@ -1,0 +1,155 @@
+"""CLI for running the fraud-investigation agent on a synthetic alert.
+
+Examples
+--------
+
+Quick CRITICAL alert (uses the deterministic stub LLM):
+
+    python scripts/investigate.py --score 0.95 --amount 4210
+
+Same, against a running Ollama daemon:
+
+    OLLAMA_BASE_URL=http://localhost:11434 \\
+        python scripts/investigate.py --score 0.95 --amount 4210 --use-ollama
+
+Replay an alert against a live API:
+
+    python scripts/investigate.py --score 0.95 --amount 4210 --api http://localhost:8000
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+from fraud_detection.agent import (
+    AgentDeps,
+    StubProvider,
+    get_llm,
+    investigate,
+    new_state,
+)
+from fraud_detection.serving.schemas import FraudPrediction, risk_level
+from fraud_detection.utils.logging import configure_logging, get_logger
+
+log = get_logger(__name__)
+
+
+@click.command(help="Run the LangGraph fraud investigator on a synthetic alert.")
+@click.option("--transaction-id", default="demo-001", help="Synthetic transaction id.")
+@click.option("--card", "card_id", default=9999, type=int, help="Synthetic card id.")
+@click.option("--amount", default=420.0, type=float, help="Transaction amount in USD.")
+@click.option("--score", default=0.85, type=float, help="Fraud score in [0,1].")
+@click.option("--use-ollama", is_flag=True, help="Try the real Ollama provider.")
+@click.option(
+    "--api",
+    default=None,
+    type=str,
+    help="If set, POST the request to a running API instead of running locally.",
+)
+@click.option("--json-output", "as_json", is_flag=True, help="Print the report as JSON.")
+def main(
+    transaction_id: str,
+    card_id: int,
+    amount: float,
+    score: float,
+    use_ollama: bool,
+    api: str | None,
+    as_json: bool,
+) -> int:
+    """Entry point."""
+    configure_logging(level="INFO", json=False)
+
+    pred = FraudPrediction(
+        transaction_id=transaction_id,
+        fraud_probability=score,
+        fraud_score=score,
+        risk_level=risk_level(score),
+        is_fraud_predicted=score >= 0.7,
+        threshold=0.7,
+    )
+    request: dict[str, Any] = {
+        "transaction_id": transaction_id,
+        "transaction_dt": 1_500_000,
+        "transaction_amt": amount,
+        "card1": card_id,
+        "product_cd": "W",
+    }
+
+    if api:
+        report = _hit_api(api, request, pred)
+    else:
+        llm = get_llm(prefer_ollama=use_ollama) if use_ollama else StubProvider()
+        deps = AgentDeps(llm=llm)
+        state = new_state(
+            transaction_id=transaction_id,
+            prediction=pred,
+            request=request,
+        )
+        report = investigate(state, deps=deps).model_dump(mode="json")
+
+    if as_json:
+        click.echo(json.dumps(report, indent=2, default=str))
+    else:
+        _print_pretty(report)
+    return 0
+
+
+def _hit_api(base_url: str, request: dict[str, Any], pred: FraudPrediction) -> dict[str, Any]:
+    import httpx  # type: ignore[import-not-found]
+
+    payload = {
+        "transaction": request,
+        "prediction": pred.model_dump(mode="json"),
+    }
+    log.info("investigate_via_api", url=f"{base_url}/api/v1/investigate")
+    resp = httpx.post(f"{base_url.rstrip('/')}/api/v1/investigate", json=payload, timeout=60.0)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _print_pretty(report: dict[str, Any]) -> None:
+    click.echo("=" * 60)
+    click.echo(f"ALERT  {report.get('alert_id')}  (transaction {report.get('transaction_id')})")
+    click.echo(
+        f"  risk_level={report.get('risk_level')}  "
+        f"depth={report.get('depth')}  "
+        f"score={report.get('fraud_score'):.3f}"
+    )
+    click.echo(
+        f"  recommended_action={report.get('recommended_action').upper()}  "
+        f"confidence={report.get('confidence'):.2f}"
+    )
+    click.echo(
+        f"  human_review={report.get('requires_human_review')}  "
+        f"model={report.get('model')}  "
+        f"elapsed={report.get('elapsed_ms'):.1f} ms"
+    )
+    click.echo("-" * 60)
+    click.echo("SUMMARY:")
+    click.echo(f"  {report.get('summary')}")
+    click.echo("NARRATIVE:")
+    click.echo(f"  {report.get('narrative')}")
+    click.echo("MATCHED PATTERNS:")
+    for p in report.get("matched_patterns", []):
+        click.echo(f"  - {p['name']:<18s} conf={p['confidence']:.2f}  {p['rationale']}")
+    click.echo("ENTITY RISKS:")
+    for e in report.get("entity_risks", []):
+        click.echo(
+            f"  - {e['entity_type']:<8s} {e['entity_id']:<16s} "
+            f"score={e['risk_score']:.2f}  factors={e['contributing_factors']}"
+        )
+    click.echo("SIMILAR CASES:")
+    for c in report.get("similar_cases", []):
+        click.echo(
+            f"  - {c['case_id']:<10s} sim={c['similarity']:.3f}  "
+            f"pattern={c['pattern']}  -- {c['summary']}"
+        )
+    click.echo("=" * 60)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/fraud_detection/agent/__init__.py
+++ b/src/fraud_detection/agent/__init__.py
@@ -1,1 +1,58 @@
-"""LangGraph agentic investigator (Phase 5)."""
+"""LangGraph agentic investigator (Phase 5).
+
+Public surface
+--------------
+
+* :class:`AgentDeps`            -- DI container for nodes (LLM, stores, graph, ...).
+* :class:`AgentState`           -- mutable blackboard the LangGraph nodes share.
+* :class:`InvestigationReport`  -- the structured analyst-facing output.
+* :func:`new_state`             -- build an initial state from a :class:`FraudPrediction`.
+* :func:`investigate`           -- run the full graph end-to-end.
+* :func:`build_graph`           -- compile a reusable LangGraph runnable.
+"""
+
+from __future__ import annotations
+
+from fraud_detection.agent.case_bank import CaseBank, CaseRecord
+from fraud_detection.agent.graph import (
+    AgentDeps,
+    build_graph,
+    investigate,
+    route_by_risk_level,
+)
+from fraud_detection.agent.llm import LLMResponse, OllamaProvider, StubProvider, get_llm
+from fraud_detection.agent.neo4j_adapter import Neo4jGraphAdapter
+from fraud_detection.agent.report import build_report
+from fraud_detection.agent.state import (
+    AgentState,
+    EntityRisk,
+    FraudPattern,
+    InvestigationDepth,
+    InvestigationReport,
+    SimilarCase,
+    new_state,
+)
+from fraud_detection.agent.tracing import AgentTracer
+
+__all__ = [
+    "AgentDeps",
+    "AgentState",
+    "AgentTracer",
+    "CaseBank",
+    "CaseRecord",
+    "EntityRisk",
+    "FraudPattern",
+    "InvestigationDepth",
+    "InvestigationReport",
+    "LLMResponse",
+    "Neo4jGraphAdapter",
+    "OllamaProvider",
+    "SimilarCase",
+    "StubProvider",
+    "build_graph",
+    "build_report",
+    "get_llm",
+    "investigate",
+    "new_state",
+    "route_by_risk_level",
+]

--- a/src/fraud_detection/agent/case_bank.py
+++ b/src/fraud_detection/agent/case_bank.py
@@ -1,0 +1,229 @@
+"""Similar-case bank for the GraphRAG retrieval tool (Phase 5).
+
+Backed by FAISS when ``faiss-cpu`` is installed *and* a populated index is
+on disk; otherwise falls back to in-memory cosine similarity over a small
+seed bank. Either way the call shape is the same.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Seed bank -- 6 prototypical fraud cases, one per pattern. Hard-coded so
+# tests + cold-laptop runs always have something to retrieve.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CaseRecord:
+    case_id: str
+    pattern: str
+    summary: str
+    embedding: np.ndarray = field(repr=False)
+
+
+def _seed_bank(dim: int = 64) -> list[CaseRecord]:
+    """Six deterministic synthetic cases covering each canonical pattern.
+
+    Embeddings are generated from a per-case RNG so similarity scores are
+    reproducible across runs.
+    """
+    seeds = [
+        (
+            "CASE-001",
+            "velocity_spike",
+            "Card swiped 24x within 1 hour at unrelated merchants; spend $4,210.",
+        ),
+        ("CASE-002", "card_testing", "67 micro-charges (<=$2) across 12 merchants in 30 minutes."),
+        (
+            "CASE-003",
+            "collusion_ring",
+            "5 cards sharing a device + address; coordinated tx within 6 hours.",
+        ),
+        (
+            "CASE-004",
+            "account_takeover",
+            "New device + new shipping address + 4x average ticket; preceded by password reset.",
+        ),
+        (
+            "CASE-005",
+            "geo_anomaly",
+            "Charge originating from country B 2 hours after a charge from country A.",
+        ),
+        (
+            "CASE-006",
+            "none",
+            "Standard recurring charge from a long-trusted card; flagged by velocity heuristic.",
+        ),
+    ]
+    cases: list[CaseRecord] = []
+    for i, (cid, pat, summary) in enumerate(seeds):
+        rng = np.random.default_rng(seed=42 + i)
+        vec = rng.normal(loc=0.0, scale=1.0, size=(dim,)).astype(np.float32)
+        # Normalise to unit length so cosine == dot product.
+        n = np.linalg.norm(vec) or 1.0
+        cases.append(CaseRecord(case_id=cid, pattern=pat, summary=summary, embedding=vec / n))
+    return cases
+
+
+# ---------------------------------------------------------------------------
+# CaseBank (in-memory + optional FAISS)
+# ---------------------------------------------------------------------------
+
+
+class CaseBank:
+    """K-NN retrieval over historical fraud cases.
+
+    Use :meth:`add` to grow the bank, :meth:`search` to find the top-k
+    most similar cases to a query embedding. ``embedding_dim`` is
+    inferred from the first record added, or set explicitly for the seed.
+    """
+
+    def __init__(self, *, embedding_dim: int = 64, use_faiss: bool = True) -> None:
+        self.embedding_dim = embedding_dim
+        self._records: list[CaseRecord] = []
+        self._faiss_index: Any | None = None
+        self._use_faiss = use_faiss
+
+    # ------------------------------------------------------------------
+    # construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def with_seed(cls, *, embedding_dim: int = 64, use_faiss: bool = True) -> CaseBank:
+        bank = cls(embedding_dim=embedding_dim, use_faiss=use_faiss)
+        for rec in _seed_bank(embedding_dim):
+            bank.add(rec)
+        return bank
+
+    def add(self, record: CaseRecord) -> None:
+        if record.embedding.shape[0] != self.embedding_dim:
+            # Re-shape the dim on the first add, otherwise reject mismatches.
+            if not self._records:
+                self.embedding_dim = int(record.embedding.shape[0])
+            else:
+                raise ValueError(
+                    f"embedding shape mismatch: got {record.embedding.shape[0]}, "
+                    f"expected {self.embedding_dim}"
+                )
+        self._records.append(record)
+        # Rebuild FAISS lazily on first ``search`` call.
+        self._faiss_index = None
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+    # ------------------------------------------------------------------
+    # persistence
+    # ------------------------------------------------------------------
+
+    def save(self, path: str | Path) -> None:
+        import pickle
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("wb") as f:
+            pickle.dump(
+                {
+                    "embedding_dim": self.embedding_dim,
+                    "records": [
+                        {
+                            "case_id": r.case_id,
+                            "pattern": r.pattern,
+                            "summary": r.summary,
+                            "embedding": r.embedding,
+                        }
+                        for r in self._records
+                    ],
+                },
+                f,
+            )
+
+    @classmethod
+    def load(cls, path: str | Path) -> CaseBank:
+        import pickle
+
+        with Path(path).open("rb") as f:
+            data = pickle.load(f)
+        bank = cls(embedding_dim=int(data["embedding_dim"]))
+        for rec in data["records"]:
+            bank.add(
+                CaseRecord(
+                    case_id=rec["case_id"],
+                    pattern=rec["pattern"],
+                    summary=rec["summary"],
+                    embedding=np.asarray(rec["embedding"], dtype=np.float32),
+                )
+            )
+        return bank
+
+    # ------------------------------------------------------------------
+    # retrieval
+    # ------------------------------------------------------------------
+
+    def search(self, query: np.ndarray, *, k: int = 3) -> list[tuple[CaseRecord, float]]:
+        if not self._records:
+            return []
+        q = np.asarray(query, dtype=np.float32).reshape(-1)
+        if q.shape[0] != self.embedding_dim:
+            # If the query is the wrong size (e.g. zero-vector cold path),
+            # zero-pad / truncate for graceful behaviour.
+            adjusted = np.zeros(self.embedding_dim, dtype=np.float32)
+            n = min(q.shape[0], self.embedding_dim)
+            adjusted[:n] = q[:n]
+            q = adjusted
+        n = np.linalg.norm(q) or 1.0
+        q = q / n
+
+        # Try FAISS path first.
+        if self._use_faiss and self._faiss_index is None:
+            self._faiss_index = self._maybe_build_faiss()
+        if self._faiss_index is not None:
+            try:
+                D, idx = self._faiss_index.search(q.reshape(1, -1).astype(np.float32), k)
+                pairs = [
+                    (self._records[int(i)], float(D[0][rank]))
+                    for rank, i in enumerate(idx[0])
+                    if 0 <= int(i) < len(self._records)
+                ]
+                return pairs[:k]
+            except Exception as exc:
+                log.debug("faiss_search_failed_falling_back", error=str(exc))
+                # Fall through to numpy path
+
+        # Numpy fallback.
+        mat = np.stack([r.embedding for r in self._records])
+        sims = mat @ q  # cosine since both sides are unit-normalised
+        order = np.argsort(sims)[::-1][:k]
+        return [(self._records[int(i)], float(sims[int(i)])) for i in order]
+
+    def _maybe_build_faiss(self) -> Any | None:
+        if not self._use_faiss:
+            return None
+        try:
+            import faiss  # type: ignore[import-untyped]
+        except Exception as exc:
+            log.debug("faiss_not_installed", error=str(exc))
+            return None
+        try:
+            mat = np.stack([r.embedding for r in self._records]).astype(np.float32)
+            index = faiss.IndexFlatIP(self.embedding_dim)
+            index.add(mat)
+            log.info("faiss_index_built", n=len(self._records), dim=self.embedding_dim)
+            return index
+        except Exception as exc:
+            log.warning("faiss_index_build_failed", error=str(exc))
+            return None
+
+
+__all__ = ["CaseBank", "CaseRecord"]

--- a/src/fraud_detection/agent/graph.py
+++ b/src/fraud_detection/agent/graph.py
@@ -1,0 +1,405 @@
+"""LangGraph StateGraph orchestrating the 8 tools (Phase 5).
+
+Plan flow (page 10):
+
+    START (alert) -> Route by Risk Level
+    LOW/MEDIUM   -> quick_scan -> generate_report -> END
+    HIGH         -> gather_context -> analyze_patterns -> generate_report -> END (human review flag)
+    CRITICAL     -> full_traversal -> pattern_matching -> cross_entity_analysis
+                    -> generate_report -> END (human review flag)
+
+We expose a single :func:`investigate` entry point that builds the graph
+once and runs it for an :class:`AgentState`. The graph is also cached so
+repeated calls are cheap.
+"""
+
+from __future__ import annotations
+
+import functools
+import time
+from typing import Any
+
+from fraud_detection.agent import tools as T  # noqa: N812 -- terse alias used heavily below
+from fraud_detection.agent.case_bank import CaseBank
+from fraud_detection.agent.llm import StubProvider, get_llm
+from fraud_detection.agent.report import build_report
+from fraud_detection.agent.state import AgentState, InvestigationReport
+from fraud_detection.agent.tracing import AgentTracer
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# AgentDeps -- everything the nodes need that's not in the state.
+# ---------------------------------------------------------------------------
+
+
+class AgentDeps:
+    """Dependency container so node closures stay easy to test."""
+
+    def __init__(
+        self,
+        *,
+        llm: Any | None = None,
+        history: T.CardHistoryStore | None = None,
+        graph: Any | None = None,
+        case_bank: CaseBank | None = None,
+        embedding_lookup: dict[Any, Any] | None = None,
+        tracer: AgentTracer | None = None,
+    ) -> None:
+        self.llm = llm or get_llm(prefer_ollama=False)  # default: stub
+        self.history = history
+        self.graph = graph
+        self.case_bank = case_bank or CaseBank.with_seed()
+        self.embedding_lookup = embedding_lookup or {}
+        self.tracer = tracer or AgentTracer()
+
+
+# ---------------------------------------------------------------------------
+# Node implementations
+# ---------------------------------------------------------------------------
+
+
+def _record_tool(state: AgentState, name: str, payload: dict[str, Any]) -> None:
+    state.setdefault("evidence", {})[name] = payload  # type: ignore[index]
+    state.setdefault("tool_calls", []).append(  # type: ignore[arg-type]
+        {
+            "name": name,
+            "status": payload.get("status", "ok"),
+            "elapsed_ms": float(payload.get("elapsed_ms") or 0.0),
+        }
+    )
+
+
+def node_quick_scan(state: AgentState, deps: AgentDeps) -> AgentState:
+    """LOW / MEDIUM path -- 2 tools, no graph walks."""
+    with deps.tracer.span("quick_scan", risk=state.get("risk_level")):
+        _record_tool(
+            state,
+            "get_transaction_details",
+            T.get_transaction_details(
+                transaction=state.get("request", {}),
+                prediction=state.get("prediction", {}),
+            ),
+        )
+        _record_tool(
+            state,
+            "analyze_card_history",
+            T.analyze_card_history(
+                card_id=state.get("request", {}).get("card1"),
+                as_of_dt=state.get("request", {}).get("transaction_dt"),
+                history=deps.history,
+            ),
+        )
+    return state
+
+
+def node_gather_context(state: AgentState, deps: AgentDeps) -> AgentState:
+    """HIGH path -- collect transaction details, card history, velocity."""
+    with deps.tracer.span("gather_context", risk=state.get("risk_level")):
+        _record_tool(
+            state,
+            "get_transaction_details",
+            T.get_transaction_details(
+                transaction=state.get("request", {}),
+                prediction=state.get("prediction", {}),
+            ),
+        )
+        _record_tool(
+            state,
+            "analyze_card_history",
+            T.analyze_card_history(
+                card_id=state.get("request", {}).get("card1"),
+                as_of_dt=state.get("request", {}).get("transaction_dt"),
+                history=deps.history,
+            ),
+        )
+        _record_tool(
+            state,
+            "analyze_velocity",
+            T.analyze_velocity(
+                card_id=state.get("request", {}).get("card1"),
+                as_of_dt=state.get("request", {}).get("transaction_dt"),
+                history=deps.history,
+            ),
+        )
+    return state
+
+
+def node_analyze_patterns(state: AgentState, deps: AgentDeps) -> AgentState:
+    """HIGH path -- match patterns + retrieve similar cases."""
+    with deps.tracer.span("analyze_patterns", risk=state.get("risk_level")):
+        evidence = state.get("evidence", {}) or {}
+        history_summary = evidence.get("analyze_card_history") or {}
+        velocity_summary = evidence.get("analyze_velocity") or {}
+        neighborhood_summary = evidence.get("explore_graph_neighborhood") or {}
+        fraud_score = float((state.get("prediction") or {}).get("fraud_score") or 0.0)
+
+        _record_tool(
+            state,
+            "match_fraud_patterns",
+            T.match_fraud_patterns(
+                history_summary=history_summary,
+                velocity_summary=velocity_summary,
+                neighborhood_summary=neighborhood_summary,
+                fraud_score=fraud_score,
+            ),
+        )
+        emb = _resolve_embedding(state, deps)
+        _record_tool(
+            state,
+            "retrieve_similar_cases",
+            T.retrieve_similar_cases(embedding=emb, case_bank=deps.case_bank, k=3),
+        )
+    return state
+
+
+def node_full_traversal(state: AgentState, deps: AgentDeps) -> AgentState:
+    """CRITICAL path -- N-hop neighborhood, deeper card history, velocity."""
+    with deps.tracer.span("full_traversal", risk=state.get("risk_level")):
+        _record_tool(
+            state,
+            "get_transaction_details",
+            T.get_transaction_details(
+                transaction=state.get("request", {}),
+                prediction=state.get("prediction", {}),
+            ),
+        )
+        _record_tool(
+            state,
+            "analyze_card_history",
+            T.analyze_card_history(
+                card_id=state.get("request", {}).get("card1"),
+                as_of_dt=state.get("request", {}).get("transaction_dt"),
+                history=deps.history,
+            ),
+        )
+        _record_tool(
+            state,
+            "analyze_velocity",
+            T.analyze_velocity(
+                card_id=state.get("request", {}).get("card1"),
+                as_of_dt=state.get("request", {}).get("transaction_dt"),
+                history=deps.history,
+            ),
+        )
+        _record_tool(
+            state,
+            "explore_graph_neighborhood",
+            T.explore_graph_neighborhood(
+                transaction_id=state.get("transaction_id"),
+                card_id=state.get("request", {}).get("card1"),
+                graph=deps.graph,
+                n_hops=2,
+            ),
+        )
+    return state
+
+
+def node_pattern_matching(state: AgentState, deps: AgentDeps) -> AgentState:
+    """CRITICAL path -- pattern matcher + GraphRAG similar cases."""
+    with deps.tracer.span("pattern_matching", risk=state.get("risk_level")):
+        evidence = state.get("evidence", {}) or {}
+        fraud_score = float((state.get("prediction") or {}).get("fraud_score") or 0.0)
+        _record_tool(
+            state,
+            "match_fraud_patterns",
+            T.match_fraud_patterns(
+                history_summary=evidence.get("analyze_card_history") or {},
+                velocity_summary=evidence.get("analyze_velocity") or {},
+                neighborhood_summary=evidence.get("explore_graph_neighborhood") or {},
+                fraud_score=fraud_score,
+            ),
+        )
+        emb = _resolve_embedding(state, deps)
+        _record_tool(
+            state,
+            "retrieve_similar_cases",
+            T.retrieve_similar_cases(embedding=emb, case_bank=deps.case_bank, k=5),
+        )
+    return state
+
+
+def node_cross_entity(state: AgentState, deps: AgentDeps) -> AgentState:
+    """CRITICAL path -- per-entity-type risk decomposition."""
+    with deps.tracer.span("cross_entity", risk=state.get("risk_level")):
+        evidence = state.get("evidence", {}) or {}
+        fraud_score = float((state.get("prediction") or {}).get("fraud_score") or 0.0)
+        _record_tool(
+            state,
+            "compute_cross_entity_risk",
+            T.compute_cross_entity_risk(
+                transaction=state.get("request", {}),
+                history_summary=evidence.get("analyze_card_history") or {},
+                neighborhood_summary=evidence.get("explore_graph_neighborhood") or {},
+                fraud_score=fraud_score,
+            ),
+        )
+    return state
+
+
+def node_generate_report(state: AgentState, deps: AgentDeps) -> AgentState:
+    """Final node -- LLM synthesises the structured narrative."""
+    with deps.tracer.span("generate_report", risk=state.get("risk_level")):
+        _record_tool(
+            state,
+            "generate_investigation_report",
+            T.generate_investigation_report(
+                state_evidence=state.get("evidence", {}) or {},
+                prediction=state.get("prediction", {}) or {},
+                transaction_id=state.get("transaction_id", "?"),
+                alert_id=state.get("alert_id", "inv-unknown"),
+                depth=state.get("depth", "quick"),
+                llm=deps.llm,
+            ),
+        )
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+def route_by_risk_level(state: AgentState) -> str:
+    """Decide which downstream branch to take from the START router."""
+    risk = state.get("risk_level", "LOW")
+    if risk == "CRITICAL":
+        return "full_traversal"
+    if risk == "HIGH":
+        return "gather_context"
+    return "quick_scan"  # LOW / MEDIUM
+
+
+# ---------------------------------------------------------------------------
+# Graph builder (cached)
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=1)
+def _import_langgraph() -> tuple[Any, Any, Any]:
+    from langgraph.graph import END, START, StateGraph
+
+    return StateGraph, START, END
+
+
+def build_graph(deps: AgentDeps) -> Any:
+    """Compile the StateGraph. Returns a runnable.
+
+    The compiled graph is *not* cached at module level because it closes
+    over ``deps`` -- different deployments (different LLMs, history
+    stores, ...) need their own compiled graph. Within a single
+    deployment, callers should hold onto the compiled instance.
+    """
+    StateGraph, START, END = _import_langgraph()
+
+    workflow: Any = StateGraph(AgentState)
+
+    # Bind deps via partials so the StateGraph just sees state -> state.
+    workflow.add_node("quick_scan", functools.partial(node_quick_scan, deps=deps))
+    workflow.add_node("gather_context", functools.partial(node_gather_context, deps=deps))
+    workflow.add_node("analyze_patterns", functools.partial(node_analyze_patterns, deps=deps))
+    workflow.add_node("full_traversal", functools.partial(node_full_traversal, deps=deps))
+    workflow.add_node("pattern_matching", functools.partial(node_pattern_matching, deps=deps))
+    workflow.add_node("cross_entity", functools.partial(node_cross_entity, deps=deps))
+    workflow.add_node("generate_report", functools.partial(node_generate_report, deps=deps))
+
+    workflow.add_conditional_edges(
+        START,
+        route_by_risk_level,
+        {
+            "quick_scan": "quick_scan",
+            "gather_context": "gather_context",
+            "full_traversal": "full_traversal",
+        },
+    )
+    workflow.add_edge("quick_scan", "generate_report")
+    workflow.add_edge("gather_context", "analyze_patterns")
+    workflow.add_edge("analyze_patterns", "generate_report")
+    workflow.add_edge("full_traversal", "pattern_matching")
+    workflow.add_edge("pattern_matching", "cross_entity")
+    workflow.add_edge("cross_entity", "generate_report")
+    workflow.add_edge("generate_report", END)
+
+    return workflow.compile()
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def investigate(
+    state: AgentState,
+    *,
+    deps: AgentDeps | None = None,
+    compiled: Any | None = None,
+) -> InvestigationReport:
+    """Run the agent end-to-end and return a structured report.
+
+    Reuses ``compiled`` (the output of :func:`build_graph`) if supplied
+    so callers in a hot path don't pay the compile cost per call.
+    """
+    deps = deps or AgentDeps(llm=StubProvider())
+    runnable = compiled or build_graph(deps)
+
+    t0 = time.perf_counter()
+    log.info(
+        "agent_investigate_start",
+        alert_id=state.get("alert_id"),
+        risk_level=state.get("risk_level"),
+        depth=state.get("depth"),
+    )
+    final_state: AgentState = runnable.invoke(state)
+    report = build_report(final_state, t_started=t0)
+    log.info(
+        "agent_investigate_done",
+        alert_id=report.alert_id,
+        depth=report.depth,
+        elapsed_ms=round(report.elapsed_ms, 2),
+        recommended_action=report.recommended_action,
+        n_tools=len(report.tools_used),
+    )
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_embedding(state: AgentState, deps: AgentDeps) -> Any | None:
+    """Pick the right embedding for GraphRAG retrieval.
+
+    Strategy:
+    1. Try ``deps.embedding_lookup[card_id]`` -- typically populated from
+       the predictor's Redis cache.
+    2. Otherwise, look at the prediction's ``top_features`` and use the
+       contributions vector as a low-rank surrogate.
+    3. Otherwise return None and let the tool short-circuit.
+    """
+    card_id = (state.get("request") or {}).get("card1")
+    if card_id is not None and card_id in deps.embedding_lookup:
+        return deps.embedding_lookup[card_id]
+
+    pred = state.get("prediction") or {}
+    contribs = pred.get("top_features") or []
+    if contribs:
+        return [float(c.get("contribution") or 0.0) for c in contribs]
+    return None
+
+
+__all__ = [
+    "AgentDeps",
+    "build_graph",
+    "investigate",
+    "node_analyze_patterns",
+    "node_cross_entity",
+    "node_full_traversal",
+    "node_gather_context",
+    "node_generate_report",
+    "node_pattern_matching",
+    "node_quick_scan",
+    "route_by_risk_level",
+]

--- a/src/fraud_detection/agent/llm.py
+++ b/src/fraud_detection/agent/llm.py
@@ -1,0 +1,303 @@
+"""LLM provider for the fraud-investigation agent (Phase 5).
+
+The plan specifies *Ollama* (local LLM) via ``langchain-ollama``. We don't
+want a hard dep on a running Ollama daemon though -- tests, CI, and most
+laptops won't have one -- so this module ships two providers:
+
+* :class:`OllamaProvider`  -- real ChatOllama, used when the daemon answers.
+* :class:`StubProvider`    -- deterministic, evidence-driven narrative.
+
+:func:`get_llm` returns the first provider that connects. Callers always
+get something with the same ``invoke(system, user, **kwargs)`` shape.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public response shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LLMResponse:
+    """What every provider returns. ``parsed`` is best-effort JSON."""
+
+    content: str
+    parsed: dict[str, Any] = field(default_factory=dict)
+    model: str = "unknown"
+    elapsed_ms: float = 0.0
+    is_stub: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Stub provider (deterministic, no network)
+# ---------------------------------------------------------------------------
+
+
+class StubProvider:
+    """Generates a structured report from evidence without an LLM.
+
+    The output JSON shape matches what the real Ollama provider returns
+    so the rest of the agent (and the report generator) can stay model-
+    agnostic. Used in tests + on laptops without a running Ollama daemon.
+    """
+
+    name = "stub"
+
+    def __init__(self, *, action_rule: Callable[[float, str], str] | None = None) -> None:
+        self.action_rule = action_rule or _default_action_rule
+
+    def invoke(self, system: str, user: str, **_: Any) -> LLMResponse:
+        # Pull a few hints from the rendered user prompt so the stub feels
+        # responsive to the evidence. The prompt is built by
+        # :data:`agent.prompts.REPORT_TEMPLATE` so we can grep for the
+        # structured fields it interpolates.
+        score = _grep_float(user, r"Fraud score:\s*([0-9.]+)") or 0.0
+        risk = _grep_str(user, r"Risk level:\s*(LOW|MEDIUM|HIGH|CRITICAL)") or "LOW"
+        txn = _grep_str(user, r"transaction\s+([A-Za-z0-9_-]+)") or "?"
+
+        action = self.action_rule(score, risk)
+        patterns = _stub_match_patterns(user, score)
+        evidence_summary = _summarise_evidence(user)
+
+        narrative = (
+            f"Transaction {txn} scored {score:.3f} (risk {risk}). "
+            f"{evidence_summary} "
+            f"Recommended action: {action}."
+        ).strip()
+
+        payload: dict[str, Any] = {
+            "summary": f"{risk} risk on transaction {txn} (score {score:.2f}).",
+            "narrative": narrative,
+            "recommended_action": action,
+            "confidence": min(0.95, max(0.4, score if score > 0 else 0.5)),
+            "matched_patterns": patterns,
+        }
+        return LLMResponse(
+            content=json.dumps(payload),
+            parsed=payload,
+            model=self.name,
+            is_stub=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Ollama provider (real langchain-ollama)
+# ---------------------------------------------------------------------------
+
+
+class OllamaProvider:
+    """Calls a local Ollama server via ``langchain-ollama``.
+
+    The provider is constructed lazily so importing this module doesn't
+    require ``langchain-ollama`` to be installed.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = "llama3.1:8b",
+        base_url: str | None = None,
+        temperature: float = 0.1,
+        request_timeout: float = 30.0,
+    ) -> None:
+        self.model = model
+        self.base_url = base_url or os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+        self.temperature = temperature
+        self.request_timeout = request_timeout
+        self._client: Any | None = None
+
+    @property
+    def name(self) -> str:
+        return self.model
+
+    def connect(self) -> bool:
+        try:
+            from langchain_ollama import ChatOllama  # type: ignore[import-untyped]
+        except Exception as exc:
+            log.warning("ollama_module_unavailable", error=str(exc))
+            return False
+        try:
+            self._client = ChatOllama(
+                model=self.model,
+                base_url=self.base_url,
+                temperature=self.temperature,
+                num_predict=512,
+                timeout=self.request_timeout,
+            )
+            log.info("ollama_provider_ready", model=self.model, base_url=self.base_url)
+            return True
+        except Exception as exc:
+            log.warning("ollama_provider_init_failed", error=str(exc))
+            self._client = None
+            return False
+
+    def invoke(self, system: str, user: str, **kwargs: Any) -> LLMResponse:
+        if self._client is None:
+            raise RuntimeError("OllamaProvider not connected")
+        # langchain-ollama's ChatOllama takes a list of (role, text) tuples.
+        import time
+
+        t0 = time.perf_counter()
+        msg = self._client.invoke(  # type: ignore[union-attr]
+            [
+                ("system", system),
+                ("human", user),
+            ],
+            **kwargs,
+        )
+        elapsed = (time.perf_counter() - t0) * 1000
+        content = getattr(msg, "content", str(msg))
+        parsed = _try_parse_json(content)
+        return LLMResponse(
+            content=content,
+            parsed=parsed,
+            model=self.model,
+            elapsed_ms=elapsed,
+            is_stub=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def get_llm(
+    *,
+    prefer_ollama: bool | None = None,
+    model: str | None = None,
+) -> StubProvider | OllamaProvider:
+    """Return the first available LLM provider.
+
+    Resolution order:
+
+    1. If ``FRAUD_AGENT_LLM=stub``  -> :class:`StubProvider`.
+    2. Otherwise try Ollama (``OllamaProvider.connect()``).
+    3. Fall back to :class:`StubProvider`.
+
+    Setting ``prefer_ollama=False`` bypasses the network call (useful in
+    tests).
+    """
+    explicit = os.environ.get("FRAUD_AGENT_LLM", "").lower()
+    if explicit == "stub":
+        log.info("agent_llm_stub_forced")
+        return StubProvider()
+    if prefer_ollama is False or explicit == "off":
+        return StubProvider()
+
+    provider = OllamaProvider(model=model or os.environ.get("OLLAMA_MODEL", "llama3.1:8b"))
+    if provider.connect():
+        return provider
+
+    log.info("agent_llm_falling_back_to_stub")
+    return StubProvider()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _try_parse_json(text: str) -> dict[str, Any]:
+    if not text:
+        return {}
+    # The model sometimes wraps JSON in ```json ... ``` fences.
+    cleaned = text.strip()
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", cleaned, re.DOTALL)
+    if fence:
+        cleaned = fence.group(1)
+    # Or it puts prose around it -- grab the outermost {...}.
+    if not cleaned.startswith("{"):
+        m = re.search(r"\{.*\}", cleaned, re.DOTALL)
+        if m:
+            cleaned = m.group(0)
+    try:
+        obj = json.loads(cleaned)
+    except json.JSONDecodeError:
+        return {}
+    return obj if isinstance(obj, dict) else {}
+
+
+def _grep_float(text: str, pattern: str) -> float | None:
+    m = re.search(pattern, text)
+    if not m:
+        return None
+    try:
+        return float(m.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def _grep_str(text: str, pattern: str) -> str | None:
+    m = re.search(pattern, text)
+    return m.group(1) if m else None
+
+
+def _default_action_rule(score: float, risk: str) -> str:
+    if risk == "CRITICAL" or score >= 0.9:
+        return "decline"
+    if risk == "HIGH":
+        return "escalate"
+    if risk == "MEDIUM":
+        return "review"
+    return "approve"
+
+
+_PATTERN_KEYWORDS: list[tuple[str, str]] = [
+    ("velocity_spike", r"velocity[_ ]spike|spike|burst|tx_per_hour|velocity_1h"),
+    ("card_testing", r"card[_ ]testing|small.+amount|micro[_ ]?charge"),
+    ("collusion_ring", r"ring|collus|shared[_ ]device|shared[_ ]address"),
+    ("account_takeover", r"new[_ ]device|account[_ ]takeover|password[_ ]reset"),
+    ("geo_anomaly", r"geo[_ ]?anomaly|country[_ ]mismatch|distance"),
+]
+
+
+def _stub_match_patterns(prompt: str, score: float) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for name, kw in _PATTERN_KEYWORDS:
+        if re.search(kw, prompt, re.IGNORECASE):
+            out.append(
+                {
+                    "name": name,
+                    "confidence": min(0.9, max(0.3, score if score > 0 else 0.5)),
+                    "rationale": f"Matched keyword pattern '{name}' in evidence.",
+                }
+            )
+    if not out and score >= 0.7:
+        out.append(
+            {
+                "name": "velocity_spike",
+                "confidence": float(score),
+                "rationale": "High score with no specific keyword match -- defaulting to velocity_spike.",
+            }
+        )
+    return out[:3]
+
+
+def _summarise_evidence(prompt: str) -> str:
+    """Pick a short prose summary out of an EVIDENCE block."""
+    m = re.search(r"==== EVIDENCE ====\n(.*?)\n==== TASK ====", prompt, re.DOTALL)
+    if not m:
+        return "Evidence is sparse."
+    block = m.group(1)
+    # Take the first 3 non-empty lines for the stub prose.
+    lines = [ln.strip() for ln in block.splitlines() if ln.strip()][:3]
+    if not lines:
+        return "Evidence is sparse."
+    return " ".join(lines)
+
+
+__all__ = ["LLMResponse", "OllamaProvider", "StubProvider", "get_llm"]

--- a/src/fraud_detection/agent/neo4j_adapter.py
+++ b/src/fraud_detection/agent/neo4j_adapter.py
@@ -1,0 +1,183 @@
+"""Neo4j adapter for the agent's graph-traversal tool (Phase 5).
+
+The plan (page 10) specifies that ``explore_graph_neighborhood`` should
+walk a Neo4j graph -- the docker-compose stack already runs a
+``neo4j:5-community`` container. This module provides a thin
+``.neighbors(node_id)``-shaped wrapper so the existing tool keeps
+working unchanged when callers pass an instance to ``AgentDeps(graph=...)``.
+
+Design rules (matching the rest of Phase 4/5):
+
+* Optional dependency -- the ``neo4j`` driver is in the ``[agent]``
+  extras; absence shouldn't break imports of the rest of the agent.
+* Graceful fallback -- if the database isn't reachable we mark the
+  adapter ``connected=False`` and ``.neighbors`` returns an empty list
+  rather than crashing the investigation loop.
+* No state mutation in ``.neighbors`` -- read-only Cypher, side-effect
+  free, safe to call from concurrent agent runs.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from fraud_detection.utils.logging import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover -- typing only
+    pass
+
+
+log = get_logger(__name__)
+
+
+# Default Cypher used by ``neighbors()``. Pulls peer cards that share a
+# device or address with the seed card -- which is exactly the
+# ``card-card`` projection Phase 2 builds in PyG.
+DEFAULT_NEIGHBOR_QUERY = (
+    "MATCH (c:Card {id: $node_id})-[:SHARED_DEVICE|SHARED_ADDRESS]-(peer:Card) "
+    "RETURN DISTINCT peer.id AS peer_id "
+    "LIMIT $limit"
+)
+
+
+class Neo4jGraphAdapter:
+    """``.neighbors(node)``-compatible adapter backed by Neo4j.
+
+    Pluggable into :class:`fraud_detection.agent.AgentDeps` via the
+    ``graph`` kwarg, alongside any other ``.neighbors``-shaped object
+    (networkx graphs, dicts, ...).
+
+    Parameters
+    ----------
+    uri
+        bolt:// URL of the Neo4j server. Defaults to ``NEO4J_URI`` env
+        var, then ``bolt://localhost:7687``.
+    user / password
+        Auth credentials. Default to ``NEO4J_USER`` / ``NEO4J_PASSWORD``
+        env vars.
+    database
+        Target database. Defaults to ``neo4j``.
+    neighbor_query
+        Cypher to use for :meth:`neighbors`. Must take ``$node_id`` and
+        ``$limit`` parameters and return a single column of peer ids.
+    default_limit
+        Default ``LIMIT`` clause value.
+    """
+
+    def __init__(
+        self,
+        *,
+        uri: str | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        database: str = "neo4j",
+        neighbor_query: str = DEFAULT_NEIGHBOR_QUERY,
+        default_limit: int = 100,
+    ) -> None:
+        self.uri = uri or os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+        self.user = user or os.environ.get("NEO4J_USER", "neo4j")
+        self.password = password or os.environ.get("NEO4J_PASSWORD", "neo4j")
+        self.database = database
+        self.neighbor_query = neighbor_query
+        self.default_limit = int(default_limit)
+
+        self._driver: Any | None = None
+        self._connected = False
+
+    # ------------------------------------------------------------------
+    # connect
+    # ------------------------------------------------------------------
+
+    def connect(self) -> bool:
+        """Open a driver and verify connectivity.
+
+        Returns ``True`` on success. On failure we log a warning and
+        leave the adapter in disconnected mode -- :meth:`neighbors`
+        will then yield an empty list rather than raise.
+        """
+        try:
+            from neo4j import GraphDatabase  # type: ignore[import-untyped]
+        except Exception as exc:
+            log.warning("neo4j_module_unavailable", error=str(exc))
+            self._driver = None
+            self._connected = False
+            return False
+        try:
+            self._driver = GraphDatabase.driver(self.uri, auth=(self.user, self.password))
+            # Hit the server cheaply to make sure the URL is reachable.
+            self._driver.verify_connectivity()
+            self._connected = True
+            log.info("neo4j_connected", uri=self.uri, database=self.database)
+        except Exception as exc:
+            log.warning("neo4j_connect_failed_using_disconnected", error=str(exc))
+            try:
+                if self._driver is not None:
+                    self._driver.close()
+            except Exception:
+                pass
+            self._driver = None
+            self._connected = False
+        return self._connected
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    # ------------------------------------------------------------------
+    # query
+    # ------------------------------------------------------------------
+
+    def neighbors(self, node_id: int | str, *, limit: int | None = None) -> list[int | str]:
+        """Return peer-card ids one hop away from ``node_id``.
+
+        Mirrors the ``.neighbors`` interface of ``networkx.Graph`` so
+        the agent's :func:`explore_graph_neighborhood` tool can use
+        either backend interchangeably.
+        """
+        if not self._connected or self._driver is None:
+            return []
+        cap = int(limit if limit is not None else self.default_limit)
+        try:
+            with self._driver.session(database=self.database) as session:
+                result = session.run(
+                    self.neighbor_query,
+                    node_id=node_id,
+                    limit=cap,
+                )
+                # ``record["peer_id"]`` matches the alias in the default
+                # query; if the caller passed a custom query we just
+                # take the first column so we don't have to teach the
+                # adapter the alias.
+                rows = result.data()
+                if not rows:
+                    return []
+                first_key = next(iter(rows[0].keys()))
+                return [r[first_key] for r in rows if r.get(first_key) is not None]
+        except Exception as exc:
+            log.warning("neo4j_neighbors_query_failed", error=str(exc), node_id=str(node_id))
+            return []
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        if self._driver is not None:
+            try:
+                self._driver.close()
+            except Exception as exc:
+                log.warning("neo4j_close_failed", error=str(exc))
+            finally:
+                self._driver = None
+                self._connected = False
+
+    def __enter__(self) -> Neo4jGraphAdapter:
+        self.connect()
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.close()
+
+
+__all__ = ["DEFAULT_NEIGHBOR_QUERY", "Neo4jGraphAdapter"]

--- a/src/fraud_detection/agent/prompts.py
+++ b/src/fraud_detection/agent/prompts.py
@@ -1,0 +1,68 @@
+"""LLM prompts for the fraud-investigation agent (Phase 5).
+
+The agent uses a small handful of prompts; we keep them in one module so
+they can be unit-tested for the placeholder names + iterated on without
+hunting through ``graph.py``.
+"""
+
+from __future__ import annotations
+
+from string import Template
+
+# ---------------------------------------------------------------------------
+# System prompt -- pinned for every LLM call from the agent.
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """You are a senior fraud-investigation analyst at a payments company.
+You receive automated alerts produced by a graph neural network + XGBoost ensemble.
+Your job is to:
+
+1. Read the structured evidence collected by the upstream tools.
+2. Decide which (if any) canonical fraud pattern applies:
+   card_testing, account_takeover, collusion_ring, velocity_spike, geo_anomaly, none.
+3. Recommend exactly one action: approve, review, decline, escalate.
+4. Write a concise, factual narrative (<=180 words) summarising the case.
+
+Rules:
+- Quote concrete numbers from the evidence (e.g. "spent $4,210 across 14 cards in 1h").
+- Never invent fields or scores that aren't in the evidence.
+- Use neutral, analyst-style prose; avoid hype words like "definitely" / "obvious".
+- If evidence is thin or contradictory, recommend "review" and say so."""
+
+
+# ---------------------------------------------------------------------------
+# Templates -- caller uses ``Template.substitute(...)`` to interpolate.
+# ---------------------------------------------------------------------------
+
+REPORT_TEMPLATE = Template(
+    """ALERT $alert_id  (transaction $transaction_id)
+Risk level: $risk_level   Fraud score: $fraud_score   Depth: $depth
+
+==== EVIDENCE ====
+$evidence_block
+
+==== TASK ====
+Produce a JSON object with these keys (and nothing else):
+
+{
+  "summary":             "<=20 words describing what happened",
+  "narrative":           "<=180 word analyst paragraph",
+  "recommended_action":  one of [approve, review, decline, escalate],
+  "confidence":          float in [0, 1],
+  "matched_patterns":    [ { "name": "...", "confidence": 0.0, "rationale": "..." } ]
+}
+
+Return only the JSON. No markdown, no surrounding prose."""
+)
+
+
+# Simple text used by the deterministic stub LLM -- mirrors the JSON shape
+# above so the call sites can rely on the same parser.
+STUB_NARRATIVE_TEMPLATE = Template(
+    "Score $fraud_score (risk $risk_level) on transaction $transaction_id. "
+    "$evidence_summary "
+    "Recommended action: $recommended_action."
+)
+
+
+__all__ = ["REPORT_TEMPLATE", "STUB_NARRATIVE_TEMPLATE", "SYSTEM_PROMPT"]

--- a/src/fraud_detection/agent/report.py
+++ b/src/fraud_detection/agent/report.py
@@ -1,0 +1,142 @@
+"""Materialise an :class:`InvestigationReport` from the agent state.
+
+Separated from ``graph.py`` so it can be unit-tested without spinning up
+a LangGraph app.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from fraud_detection.agent.state import (
+    AgentState,
+    EntityRisk,
+    FraudPattern,
+    InvestigationReport,
+    SimilarCase,
+)
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+def build_report(state: AgentState, *, t_started: float | None = None) -> InvestigationReport:
+    """Translate the (mutable) agent state into a Pydantic report.
+
+    The state is expected to have already had a
+    ``generate_investigation_report`` tool call run; if it hasn't, we
+    fall back to a deterministic "no LLM" narrative built from the
+    structured evidence.
+    """
+    pred = state.get("prediction", {}) or {}
+    evidence: dict[str, Any] = state.get("evidence", {}) or {}
+    report_evidence = evidence.get("generate_investigation_report", {}) or {}
+
+    summary = report_evidence.get("summary") or _fallback_summary(state)
+    narrative = report_evidence.get("narrative") or _fallback_narrative(state)
+    action = (report_evidence.get("recommended_action") or _fallback_action(state)).lower()
+    confidence = float(report_evidence.get("confidence") or 0.5)
+    model = report_evidence.get("model") or "stub"
+
+    matched = [FraudPattern(**p) for p in (report_evidence.get("matched_patterns") or [])]
+    if not matched:
+        # Pull from match_fraud_patterns evidence if no LLM patterns came through.
+        matched = [
+            FraudPattern(**p)
+            for p in (evidence.get("match_fraud_patterns", {}) or {}).get("matched_patterns", [])
+        ]
+
+    entities = [
+        EntityRisk(**e)
+        for e in (evidence.get("compute_cross_entity_risk", {}) or {}).get("entity_risks", [])
+    ]
+    similar = [
+        SimilarCase(**c)
+        for c in (evidence.get("retrieve_similar_cases", {}) or {}).get("similar_cases", [])
+    ]
+
+    elapsed_ms = (time.perf_counter() - t_started) * 1000 if t_started is not None else 0.0
+    return InvestigationReport(
+        alert_id=state.get("alert_id", "inv-unknown"),
+        transaction_id=state.get("transaction_id", "?"),
+        risk_level=state.get("risk_level", pred.get("risk_level", "LOW")),
+        depth=state.get("depth", "quick"),
+        fraud_score=float(pred.get("fraud_score") or 0.0),
+        summary=summary,
+        narrative=narrative,
+        recommended_action=_normalise_action(action),
+        confidence=max(0.0, min(1.0, confidence)),
+        requires_human_review=bool(state.get("requires_human_review")),
+        entity_risks=entities,
+        matched_patterns=matched,
+        similar_cases=similar,
+        tools_used=list(evidence.keys()),
+        tool_calls=list(state.get("tool_calls") or []),
+        elapsed_ms=elapsed_ms,
+        model=str(model),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fallbacks (used when the LLM tool call didn't run)
+# ---------------------------------------------------------------------------
+
+
+def _fallback_summary(state: AgentState) -> str:
+    pred = state.get("prediction", {}) or {}
+    risk = pred.get("risk_level", "LOW")
+    score = float(pred.get("fraud_score") or 0.0)
+    return f"{risk} risk on transaction {state.get('transaction_id', '?')} (score {score:.2f})."
+
+
+def _fallback_narrative(state: AgentState) -> str:
+    evidence = state.get("evidence", {}) or {}
+    parts: list[str] = [_fallback_summary(state)]
+    h = evidence.get("analyze_card_history") or {}
+    if h.get("status") == "ok":
+        parts.append(
+            f"Card history: {h.get('n_transactions', 0)} txns, "
+            f"30d spend ${h.get('total_spend', 0):.0f}, "
+            f"avg ${h.get('avg_amount', 0):.2f}, "
+            f"velocity {h.get('velocity_per_hour', 0):.1f}/h, "
+            f"fraud_rate {h.get('fraud_rate', 0):.2%}."
+        )
+    n = evidence.get("explore_graph_neighborhood") or {}
+    if n.get("status") == "ok" and (n.get("n_unique_neighbors") or 0):
+        parts.append(
+            f"Card connected to {n.get('n_unique_neighbors')} peer cards via shared device/address."
+        )
+    return " ".join(parts)
+
+
+def _fallback_action(state: AgentState) -> str:
+    pred = state.get("prediction", {}) or {}
+    score = float(pred.get("fraud_score") or 0.0)
+    risk = pred.get("risk_level", "LOW")
+    if risk == "CRITICAL" or score >= 0.9:
+        return "decline"
+    if risk == "HIGH":
+        return "escalate"
+    if risk == "MEDIUM":
+        return "review"
+    return "approve"
+
+
+_VALID_ACTIONS = ("approve", "review", "decline", "escalate")
+
+
+def _normalise_action(action: str) -> str:
+    a = (action or "review").strip().lower()
+    return a if a in _VALID_ACTIONS else "review"
+
+
+__all__ = ["build_report"]
+
+
+# ---------------------------------------------------------------------------
+# Re-export Mapping for typing convenience -- silence ruff F401
+# ---------------------------------------------------------------------------
+
+_ = Mapping

--- a/src/fraud_detection/agent/state.py
+++ b/src/fraud_detection/agent/state.py
@@ -1,0 +1,171 @@
+"""State + result schemas for the LangGraph fraud-investigation agent (Phase 5).
+
+The agent is built around an :class:`AgentState` ``TypedDict`` (LangGraph
+convention) -- nodes read from / write to it as the graph executes. The
+final output is materialised as :class:`InvestigationReport`, a Pydantic
+model that's safe to expose over the FastAPI ``/api/v1/investigate``
+endpoint.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal, TypedDict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from fraud_detection.serving.schemas import FraudPrediction
+
+InvestigationDepth = Literal["quick", "standard", "deep"]
+"""The agent picks one of these depths from the alert's ``risk_level``.
+
+* ``quick``    -- LOW / MEDIUM   -> 2 tool calls, no human review
+* ``standard`` -- HIGH           -> 5 tool calls, flagged for human review
+* ``deep``     -- CRITICAL       -> 7 tool calls + cross-entity scan, human review
+"""
+
+
+# ---------------------------------------------------------------------------
+# AgentState (mutable, LangGraph carries this through every node)
+# ---------------------------------------------------------------------------
+
+
+class AgentState(TypedDict, total=False):
+    """The blackboard the LangGraph nodes share.
+
+    ``total=False`` so each node only has to populate the keys it touches;
+    we initialise the dict with sane defaults inside :func:`new_state`.
+    """
+
+    # --- inputs ----------------------------------------------------------------
+    alert_id: str
+    transaction_id: int | str
+    prediction: dict[str, Any]  # serialised FraudPrediction
+    request: dict[str, Any]  # serialised TransactionRequest
+    risk_level: Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+    depth: InvestigationDepth
+
+    # --- evidence (each tool appends a chunk keyed by its name) ----------------
+    evidence: dict[str, Any]
+    tool_calls: list[dict[str, Any]]  # audit log: name, latency_ms, status
+
+    # --- outputs ---------------------------------------------------------------
+    report: dict[str, Any]  # serialised InvestigationReport
+    requires_human_review: bool
+    errors: list[str]
+
+
+def new_state(
+    *,
+    transaction_id: int | str,
+    prediction: FraudPrediction,
+    request: dict[str, Any] | None = None,
+    alert_id: str | None = None,
+) -> AgentState:
+    """Build a fresh :class:`AgentState` from a scoring decision."""
+    risk_level = prediction.risk_level
+    depth: InvestigationDepth = (
+        "deep" if risk_level == "CRITICAL" else "standard" if risk_level == "HIGH" else "quick"
+    )
+    return AgentState(  # type: ignore[typeddict-item]
+        alert_id=alert_id or f"inv-{transaction_id}",
+        transaction_id=transaction_id,
+        prediction=prediction.model_dump(mode="json"),
+        request=request or {},
+        risk_level=risk_level,
+        depth=depth,
+        evidence={},
+        tool_calls=[],
+        report={},
+        requires_human_review=risk_level in ("HIGH", "CRITICAL"),
+        errors=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# InvestigationReport (the agent's final, user-facing output)
+# ---------------------------------------------------------------------------
+
+
+class EntityRisk(BaseModel):
+    """Risk factor breakdown for a single entity (card / device / email / ...)."""
+
+    entity_type: Literal["card", "device", "email", "ip", "merchant"]
+    entity_id: str
+    risk_score: float = Field(..., ge=0.0, le=1.0)
+    contributing_factors: list[str] = Field(default_factory=list)
+
+
+class FraudPattern(BaseModel):
+    """A canonical fraud pattern matched against the evidence."""
+
+    name: Literal[
+        "card_testing",
+        "account_takeover",
+        "collusion_ring",
+        "velocity_spike",
+        "geo_anomaly",
+        "none",
+    ]
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    rationale: str = ""
+
+
+class SimilarCase(BaseModel):
+    """One row of the GraphRAG similar-case table."""
+
+    case_id: str
+    similarity: float = Field(..., ge=0.0, le=1.0)
+    pattern: str = "unknown"
+    summary: str = ""
+
+
+class InvestigationReport(BaseModel):
+    """Structured narrative the agent emits at the end of every run.
+
+    Designed to be both machine-readable (for the dashboard) *and*
+    analyst-readable (the ``narrative`` field is a paragraph of prose).
+    """
+
+    model_config = ConfigDict(protected_namespaces=())
+
+    alert_id: str
+    transaction_id: int | str
+    risk_level: Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+    depth: InvestigationDepth
+    fraud_score: float = Field(..., ge=0.0, le=1.0)
+
+    # core narrative
+    summary: str
+    narrative: str
+    recommended_action: Literal[
+        "approve",
+        "review",
+        "decline",
+        "escalate",
+    ]
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    requires_human_review: bool = False
+
+    # structured evidence
+    entity_risks: list[EntityRisk] = Field(default_factory=list)
+    matched_patterns: list[FraudPattern] = Field(default_factory=list)
+    similar_cases: list[SimilarCase] = Field(default_factory=list)
+
+    # bookkeeping
+    tools_used: list[str] = Field(default_factory=list)
+    tool_calls: list[dict[str, Any]] = Field(default_factory=list)
+    elapsed_ms: float = 0.0
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    model: str = "stub"  # set to the LLM model id when an LLM was used
+
+
+__all__ = [
+    "AgentState",
+    "EntityRisk",
+    "FraudPattern",
+    "InvestigationDepth",
+    "InvestigationReport",
+    "SimilarCase",
+    "new_state",
+]

--- a/src/fraud_detection/agent/tools.py
+++ b/src/fraud_detection/agent/tools.py
@@ -1,0 +1,719 @@
+"""The 8 investigation tools the agent uses (Phase 5).
+
+The plan (page 10) lists them as:
+
+    1. get_transaction_details       -- record + prediction explanation
+    2. analyze_card_history          -- 30d count / spend / avg / fraud / velocity
+    3. explore_graph_neighborhood    -- N-hop entity neighborhood (Neo4j or networkx)
+    4. match_fraud_patterns          -- card_testing / takeover / ring / velocity / geo
+    5. retrieve_similar_cases        -- GraphRAG: GNN embeddings + FAISS
+    6. analyze_velocity              -- multi-window (1h/6h/24h) vs. baseline
+    7. compute_cross_entity_risk     -- per-entity-type risk scores
+    8. generate_investigation_report -- LLM synthesises everything
+
+We keep them as plain Python functions so they're trivially unit-testable
+and the LangGraph nodes can compose them however they like. Each tool:
+
+* Accepts a small, typed kwargs payload (not the whole agent state).
+* Returns a JSON-serialisable ``dict`` with a ``status`` field.
+* Logs structured timings.
+* Falls back gracefully when its real data source (CardHistoryStore,
+  Neo4j, FAISS, ...) isn't wired up.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+import time
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from fraud_detection.agent.case_bank import CaseBank
+from fraud_detection.agent.state import EntityRisk, FraudPattern, SimilarCase
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tool registry -- name -> callable. Used by the graph nodes + tests.
+# ---------------------------------------------------------------------------
+
+TOOL_NAMES: tuple[str, ...] = (
+    "get_transaction_details",
+    "analyze_card_history",
+    "explore_graph_neighborhood",
+    "match_fraud_patterns",
+    "retrieve_similar_cases",
+    "analyze_velocity",
+    "compute_cross_entity_risk",
+    "generate_investigation_report",
+)
+
+
+# ---------------------------------------------------------------------------
+# Optional data source (in-memory store) -- the real serving stack would
+# wire these to Feast / Neo4j / Redis. Tests + offline runs use this.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HistoricalTransaction:
+    transaction_id: int | str
+    transaction_dt: int  # seconds since IEEE-CIS epoch
+    transaction_amt: float
+    is_fraud: int = 0
+    card_id: int | str | None = None
+    device_id: str | None = None
+    email: str | None = None
+    ip: str | None = None
+    merchant: str | None = None
+
+
+class CardHistoryStore:
+    """In-memory key/value mock for card-level history.
+
+    The serving layer can replace this with a Feast online-store call
+    without changing the tool signatures. Keys are ``card_id``; values
+    are sorted lists of :class:`HistoricalTransaction`.
+    """
+
+    def __init__(self) -> None:
+        self._by_card: dict[int | str, list[HistoricalTransaction]] = {}
+
+    def add(self, txn: HistoricalTransaction) -> None:
+        if txn.card_id is None:
+            return
+        self._by_card.setdefault(txn.card_id, []).append(txn)
+
+    def card_history(
+        self,
+        card_id: int | str,
+        *,
+        as_of_dt: int | None = None,
+        window_seconds: int | None = None,
+    ) -> list[HistoricalTransaction]:
+        rows = list(self._by_card.get(card_id, ()))
+        if as_of_dt is not None:
+            rows = [r for r in rows if r.transaction_dt <= as_of_dt]
+            if window_seconds is not None:
+                cutoff = as_of_dt - int(window_seconds)
+                rows = [r for r in rows if r.transaction_dt >= cutoff]
+        rows.sort(key=lambda r: r.transaction_dt)
+        return rows
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: get_transaction_details
+# ---------------------------------------------------------------------------
+
+
+def get_transaction_details(
+    *,
+    transaction: Mapping[str, Any],
+    prediction: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Echo the transaction + the model's prediction explanation."""
+    t0 = time.perf_counter()
+    top_features = list(prediction.get("top_features") or [])
+    out = {
+        "status": "ok",
+        "tool": "get_transaction_details",
+        "transaction_id": transaction.get("transaction_id"),
+        "transaction_amt": transaction.get("transaction_amt"),
+        "transaction_dt": transaction.get("transaction_dt"),
+        "product_cd": transaction.get("product_cd"),
+        "card_id": transaction.get("card1"),
+        "device_type": transaction.get("device_type") or transaction.get("DeviceType"),
+        "p_emaildomain": transaction.get("p_emaildomain") or transaction.get("P_emaildomain"),
+        "fraud_score": prediction.get("fraud_score"),
+        "risk_level": prediction.get("risk_level"),
+        "is_fraud_predicted": prediction.get("is_fraud_predicted"),
+        "model_version": prediction.get("model_version"),
+        "top_features": top_features[:5],
+        "elapsed_ms": (time.perf_counter() - t0) * 1000,
+    }
+    log.debug("tool_get_transaction_details", elapsed_ms=out["elapsed_ms"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: analyze_card_history
+# ---------------------------------------------------------------------------
+
+
+def analyze_card_history(
+    *,
+    card_id: int | str | None,
+    as_of_dt: int | None = None,
+    window_days: int = 30,
+    history: CardHistoryStore | None = None,
+) -> dict[str, Any]:
+    """30-day card-level rollup: count, spend, avg, fraud, velocity."""
+    t0 = time.perf_counter()
+    if card_id is None or history is None:
+        return _empty(
+            tool="analyze_card_history",
+            reason="missing_card_id_or_store" if history is None else "missing_card_id",
+            elapsed_ms=(time.perf_counter() - t0) * 1000,
+        )
+
+    rows = history.card_history(
+        card_id,
+        as_of_dt=as_of_dt,
+        window_seconds=window_days * 86400 if as_of_dt is not None else None,
+    )
+    if not rows:
+        return _empty(
+            tool="analyze_card_history",
+            reason="no_history",
+            card_id=str(card_id),
+            elapsed_ms=(time.perf_counter() - t0) * 1000,
+        )
+
+    amts = [r.transaction_amt for r in rows]
+    fraud_count = sum(r.is_fraud for r in rows)
+    velocity = _velocity_per_hour(rows, as_of_dt=as_of_dt)
+    out = {
+        "status": "ok",
+        "tool": "analyze_card_history",
+        "card_id": str(card_id),
+        "n_transactions": len(rows),
+        "total_spend": float(sum(amts)),
+        "avg_amount": float(statistics.fmean(amts)) if amts else 0.0,
+        "max_amount": float(max(amts)) if amts else 0.0,
+        "fraud_count": int(fraud_count),
+        "fraud_rate": float(fraud_count) / len(rows) if rows else 0.0,
+        "velocity_per_hour": velocity,
+        "window_days": window_days,
+        "elapsed_ms": (time.perf_counter() - t0) * 1000,
+    }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tool 3: explore_graph_neighborhood
+# ---------------------------------------------------------------------------
+
+
+def explore_graph_neighborhood(
+    *,
+    transaction_id: int | str,
+    card_id: int | str | None = None,
+    graph: Any | None = None,
+    n_hops: int = 2,
+) -> dict[str, Any]:
+    """Walk N hops over a card-card / shared-device graph.
+
+    ``graph`` may be a ``networkx.Graph`` or anything exposing
+    ``neighbors(node)``. When absent we return a stub describing what
+    we'd have done.
+    """
+    t0 = time.perf_counter()
+    if graph is None or card_id is None:
+        return _empty(
+            tool="explore_graph_neighborhood",
+            reason="no_graph_or_card_id",
+            elapsed_ms=(time.perf_counter() - t0) * 1000,
+            n_hops=n_hops,
+        )
+
+    visited: set[Any] = set()
+    frontier: set[Any] = {card_id}
+    levels: list[set[Any]] = []
+    for _ in range(max(1, n_hops)):
+        next_frontier: set[Any] = set()
+        for node in frontier:
+            visited.add(node)
+            try:
+                neighbors = list(graph.neighbors(node))  # type: ignore[union-attr]
+            except Exception:
+                neighbors = []
+            for nb in neighbors:
+                if nb not in visited:
+                    next_frontier.add(nb)
+        levels.append(next_frontier)
+        frontier = next_frontier
+        if not frontier:
+            break
+
+    n_unique = sum(len(level) for level in levels)
+    return {
+        "status": "ok",
+        "tool": "explore_graph_neighborhood",
+        "transaction_id": transaction_id,
+        "card_id": str(card_id),
+        "n_hops": n_hops,
+        "n_unique_neighbors": n_unique,
+        "neighbors_by_hop": [[str(n) for n in level] for level in levels],
+        "elapsed_ms": (time.perf_counter() - t0) * 1000,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 4: match_fraud_patterns
+# ---------------------------------------------------------------------------
+
+
+_VELOCITY_SPIKE_THRESHOLD = 5.0  # tx/hour
+_CARD_TESTING_AVG_AMT = 5.0  # USD
+_CARD_TESTING_MIN_TX = 10
+_RING_NEIGHBORHOOD = 4  # n_unique_neighbors
+
+
+def match_fraud_patterns(
+    *,
+    history_summary: Mapping[str, Any] | None = None,
+    velocity_summary: Mapping[str, Any] | None = None,
+    neighborhood_summary: Mapping[str, Any] | None = None,
+    fraud_score: float = 0.0,
+) -> dict[str, Any]:
+    """Match the canonical fraud patterns against tool 2/3/6 evidence."""
+    t0 = time.perf_counter()
+    matched: list[FraudPattern] = []
+
+    # velocity_spike
+    velocity_per_hour = _f((history_summary or {}).get("velocity_per_hour")) or 0.0
+    velocity_1h = _f((velocity_summary or {}).get("velocity_1h")) or 0.0
+    velocity_baseline = _f((velocity_summary or {}).get("baseline_per_hour")) or 0.0
+    if velocity_per_hour >= _VELOCITY_SPIKE_THRESHOLD or (
+        velocity_1h >= 3.0 and velocity_baseline > 0 and velocity_1h >= 3 * velocity_baseline
+    ):
+        conf = min(0.95, max(0.5, velocity_per_hour / 20.0 + fraud_score / 2.0))
+        matched.append(
+            FraudPattern(
+                name="velocity_spike",
+                confidence=conf,
+                rationale=f"Velocity {velocity_per_hour:.1f}/h vs baseline "
+                f"{velocity_baseline:.1f}/h (1h window: {velocity_1h:.1f}).",
+            )
+        )
+
+    # card_testing
+    n_tx = int(_f((history_summary or {}).get("n_transactions")) or 0)
+    avg_amt = _f((history_summary or {}).get("avg_amount")) or 0.0
+    if n_tx >= _CARD_TESTING_MIN_TX and 0 < avg_amt <= _CARD_TESTING_AVG_AMT:
+        matched.append(
+            FraudPattern(
+                name="card_testing",
+                confidence=min(0.95, 0.5 + n_tx / 100.0),
+                rationale=f"{n_tx} transactions averaging ${avg_amt:.2f} -- micro-charge pattern.",
+            )
+        )
+
+    # collusion_ring
+    n_neighbors = int(_f((neighborhood_summary or {}).get("n_unique_neighbors")) or 0)
+    if n_neighbors >= _RING_NEIGHBORHOOD:
+        matched.append(
+            FraudPattern(
+                name="collusion_ring",
+                confidence=min(0.95, 0.5 + n_neighbors / 20.0),
+                rationale=f"Card connected to {n_neighbors} peer cards via shared device/address.",
+            )
+        )
+
+    # account_takeover
+    if (
+        history_summary
+        and float(history_summary.get("max_amount") or 0)
+        >= 4 * float(history_summary.get("avg_amount") or 1.0)
+        and float(history_summary.get("avg_amount") or 0) > 0
+    ):
+        matched.append(
+            FraudPattern(
+                name="account_takeover",
+                confidence=0.6,
+                rationale=(
+                    f"Max charge ${history_summary.get('max_amount', 0):.2f} is 4x+ the "
+                    f"30d average -- consistent with account_takeover."
+                ),
+            )
+        )
+
+    if not matched and fraud_score >= 0.7:
+        matched.append(
+            FraudPattern(
+                name="velocity_spike",
+                confidence=fraud_score,
+                rationale="High score with no specific pattern triggered; defaulting.",
+            )
+        )
+
+    if not matched:
+        matched.append(
+            FraudPattern(
+                name="none",
+                confidence=1.0 - fraud_score,
+                rationale="No canonical fraud pattern matched.",
+            )
+        )
+
+    return {
+        "status": "ok",
+        "tool": "match_fraud_patterns",
+        "matched_patterns": [p.model_dump() for p in matched],
+        "elapsed_ms": (time.perf_counter() - t0) * 1000,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 5: retrieve_similar_cases (GraphRAG)
+# ---------------------------------------------------------------------------
+
+
+def retrieve_similar_cases(
+    *,
+    embedding: Iterable[float] | np.ndarray | None,
+    case_bank: CaseBank | None = None,
+    k: int = 3,
+) -> dict[str, Any]:
+    """Find the top-k cases whose GNN embedding is closest to ``embedding``.
+
+    Falls back to an empty list if the embedding is missing. If
+    ``case_bank`` is None we build one from the seed.
+    """
+    t0 = time.perf_counter()
+    if embedding is None:
+        return _empty(
+            tool="retrieve_similar_cases",
+            reason="no_embedding",
+            similar_cases=[],
+            elapsed_ms=(time.perf_counter() - t0) * 1000,
+        )
+
+    bank = case_bank or CaseBank.with_seed()
+    q = np.asarray(list(embedding), dtype=np.float32)
+    pairs = bank.search(q, k=k)
+    similar = [
+        SimilarCase(
+            case_id=rec.case_id,
+            similarity=max(0.0, min(1.0, (sim + 1.0) / 2.0)),  # cosine -> [0,1]
+            pattern=rec.pattern,
+            summary=rec.summary,
+        )
+        for rec, sim in pairs
+    ]
+    return {
+        "status": "ok",
+        "tool": "retrieve_similar_cases",
+        "k": k,
+        "similar_cases": [s.model_dump() for s in similar],
+        "elapsed_ms": (time.perf_counter() - t0) * 1000,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 6: analyze_velocity (multi-window)
+# ---------------------------------------------------------------------------
+
+
+def analyze_velocity(
+    *,
+    card_id: int | str | None,
+    as_of_dt: int | None,
+    history: CardHistoryStore | None = None,
+    windows_seconds: tuple[int, ...] = (3600, 21600, 86400),  # 1h, 6h, 24h
+) -> dict[str, Any]:
+    """Multi-window velocity (tx/hour) vs. 30-day baseline."""
+    t0 = time.perf_counter()
+    if card_id is None or as_of_dt is None or history is None:
+        return _empty(
+            tool="analyze_velocity",
+            reason="missing_inputs",
+            elapsed_ms=(time.perf_counter() - t0) * 1000,
+            velocity_1h=0.0,
+            velocity_6h=0.0,
+            velocity_24h=0.0,
+            baseline_per_hour=0.0,
+        )
+
+    out: dict[str, Any] = {"status": "ok", "tool": "analyze_velocity"}
+    label_for = {3600: "velocity_1h", 21600: "velocity_6h", 86400: "velocity_24h"}
+    for w in windows_seconds:
+        rows = history.card_history(card_id, as_of_dt=as_of_dt, window_seconds=w)
+        # Per-hour velocity within the window.
+        hours = max(w / 3600.0, 1.0)
+        out[label_for.get(w, f"velocity_{w}s")] = float(len(rows)) / hours
+
+    baseline_rows = history.card_history(card_id, as_of_dt=as_of_dt, window_seconds=30 * 86400)
+    out["baseline_per_hour"] = float(len(baseline_rows)) / (30 * 24) if baseline_rows else 0.0
+    out["elapsed_ms"] = (time.perf_counter() - t0) * 1000
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tool 7: compute_cross_entity_risk
+# ---------------------------------------------------------------------------
+
+
+def compute_cross_entity_risk(
+    *,
+    transaction: Mapping[str, Any],
+    history_summary: Mapping[str, Any] | None = None,
+    neighborhood_summary: Mapping[str, Any] | None = None,
+    fraud_score: float = 0.0,
+) -> dict[str, Any]:
+    """Per-entity-type risk score, with contributing factors.
+
+    Five entity types: card / device / email / ip / merchant. We blend
+    the model's fraud_score with feature signals from prior tools and
+    cap each entity's score at 1.0.
+    """
+    t0 = time.perf_counter()
+    entities: list[EntityRisk] = []
+
+    base = float(fraud_score or 0.0)
+    n_neighbors = int(_f((neighborhood_summary or {}).get("n_unique_neighbors")) or 0)
+    fraud_rate = float(_f((history_summary or {}).get("fraud_rate")) or 0.0)
+    velocity = float(_f((history_summary or {}).get("velocity_per_hour")) or 0.0)
+
+    # Card
+    card_factors: list[str] = []
+    card_score = base
+    if fraud_rate > 0:
+        card_score += 0.3 * min(1.0, fraud_rate * 5)
+        card_factors.append(f"30d fraud_rate={fraud_rate:.2%}")
+    if velocity >= _VELOCITY_SPIKE_THRESHOLD:
+        card_score += 0.2
+        card_factors.append(f"velocity={velocity:.1f}/h")
+    if n_neighbors >= _RING_NEIGHBORHOOD:
+        card_score += 0.2
+        card_factors.append(f"n_peer_cards={n_neighbors}")
+    entities.append(
+        EntityRisk(
+            entity_type="card",
+            entity_id=str(transaction.get("card1") or "unknown"),
+            risk_score=_clip01(card_score),
+            contributing_factors=card_factors or ["no signal"],
+        )
+    )
+
+    # Device
+    device = transaction.get("device_type") or transaction.get("DeviceType") or "unknown"
+    device_score = base * 0.7
+    device_factors = ["model fraud_score"]
+    if n_neighbors >= _RING_NEIGHBORHOOD:
+        device_score += 0.25
+        device_factors.append("device_shared_with_peer_cards")
+    entities.append(
+        EntityRisk(
+            entity_type="device",
+            entity_id=str(device),
+            risk_score=_clip01(device_score),
+            contributing_factors=device_factors,
+        )
+    )
+
+    # Email
+    email = transaction.get("p_emaildomain") or transaction.get("P_emaildomain") or "unknown"
+    email_score = base * 0.5
+    email_factors = ["model fraud_score"]
+    if isinstance(email, str) and any(
+        marker in email for marker in ("temp", "mailinator", "10min", "guerrilla")
+    ):
+        email_score += 0.4
+        email_factors.append("disposable_email_domain")
+    entities.append(
+        EntityRisk(
+            entity_type="email",
+            entity_id=str(email),
+            risk_score=_clip01(email_score),
+            contributing_factors=email_factors,
+        )
+    )
+
+    # IP (we only have id_02 bin in IEEE-CIS -- approximate)
+    ip_id = str(transaction.get("id_02") or "unknown")
+    entities.append(
+        EntityRisk(
+            entity_type="ip",
+            entity_id=ip_id,
+            risk_score=_clip01(base * 0.6 + (0.2 if fraud_rate > 0 else 0)),
+            contributing_factors=["model fraud_score", f"30d fraud_rate={fraud_rate:.2%}"],
+        )
+    )
+
+    # Merchant
+    merchant_id = str(transaction.get("product_cd") or "W")
+    entities.append(
+        EntityRisk(
+            entity_type="merchant",
+            entity_id=merchant_id,
+            risk_score=_clip01(base * 0.4),
+            contributing_factors=["model fraud_score"],
+        )
+    )
+
+    return {
+        "status": "ok",
+        "tool": "compute_cross_entity_risk",
+        "entity_risks": [e.model_dump() for e in entities],
+        "elapsed_ms": (time.perf_counter() - t0) * 1000,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 8: generate_investigation_report
+# ---------------------------------------------------------------------------
+
+
+def generate_investigation_report(
+    *,
+    state_evidence: Mapping[str, Any],
+    prediction: Mapping[str, Any],
+    transaction_id: int | str,
+    alert_id: str,
+    depth: str,
+    llm: Any,
+) -> dict[str, Any]:
+    """Hand the evidence to the LLM and parse a structured response back."""
+    from fraud_detection.agent.prompts import REPORT_TEMPLATE, SYSTEM_PROMPT
+
+    t0 = time.perf_counter()
+    evidence_block = _render_evidence(state_evidence)
+    user_prompt = REPORT_TEMPLATE.substitute(
+        alert_id=alert_id,
+        transaction_id=transaction_id,
+        risk_level=prediction.get("risk_level", "LOW"),
+        fraud_score=f"{float(prediction.get('fraud_score') or 0):.3f}",
+        depth=depth,
+        evidence_block=evidence_block,
+    )
+
+    try:
+        resp = llm.invoke(SYSTEM_PROMPT, user_prompt)
+        parsed = resp.parsed or {}
+        out: dict[str, Any] = {
+            "status": "ok",
+            "tool": "generate_investigation_report",
+            "model": resp.model,
+            "is_stub": getattr(resp, "is_stub", False),
+            "summary": parsed.get("summary") or "",
+            "narrative": parsed.get("narrative") or resp.content,
+            "recommended_action": (parsed.get("recommended_action") or "review").lower(),
+            "confidence": float(parsed.get("confidence") or 0.5),
+            "matched_patterns": parsed.get("matched_patterns") or [],
+            "elapsed_ms": (time.perf_counter() - t0) * 1000,
+        }
+        return out
+    except Exception as exc:
+        log.exception("tool_generate_investigation_report_failed", error=str(exc))
+        return _empty(
+            tool="generate_investigation_report",
+            reason="llm_invoke_failed",
+            error=str(exc),
+            elapsed_ms=(time.perf_counter() - t0) * 1000,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _empty(*, tool: str, reason: str, **extra: Any) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "status": "skipped",
+        "tool": tool,
+        "reason": reason,
+    }
+    out.update(extra)
+    return out
+
+
+def _f(v: Any) -> float | None:
+    if v is None:
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return None if math.isnan(f) else f
+
+
+def _clip01(x: float) -> float:
+    return max(0.0, min(1.0, float(x)))
+
+
+def _velocity_per_hour(
+    rows: list[HistoricalTransaction],
+    *,
+    as_of_dt: int | None = None,
+) -> float:
+    if not rows:
+        return 0.0
+    timestamps = [r.transaction_dt for r in rows]
+    span = (max(timestamps) - min(timestamps)) if as_of_dt is None else (as_of_dt - min(timestamps))
+    span = max(span, 1)
+    hours = span / 3600.0
+    return float(len(rows)) / max(hours, 1.0)
+
+
+def _render_evidence(evidence: Mapping[str, Any]) -> str:
+    """Render the evidence dict into a compact bulleted block for the LLM."""
+    if not evidence:
+        return "(no evidence collected)"
+    lines: list[str] = []
+    for tool_name, payload in evidence.items():
+        if not isinstance(payload, Mapping):
+            continue
+        status = payload.get("status", "ok")
+        prefix = f"- [{tool_name}] ({status})"
+        # Pick out 4-6 of the most informative fields per tool.
+        keep_keys = [
+            k
+            for k in (
+                "n_transactions",
+                "total_spend",
+                "avg_amount",
+                "max_amount",
+                "fraud_count",
+                "fraud_rate",
+                "velocity_per_hour",
+                "velocity_1h",
+                "velocity_6h",
+                "velocity_24h",
+                "baseline_per_hour",
+                "n_unique_neighbors",
+                "matched_patterns",
+                "similar_cases",
+                "entity_risks",
+                "fraud_score",
+                "risk_level",
+                "transaction_amt",
+                "card_id",
+                "reason",
+            )
+            if k in payload
+        ]
+        bullets = []
+        for k in keep_keys:
+            v = payload.get(k)
+            if isinstance(v, list):
+                v = f"[{len(v)} items]"
+            elif isinstance(v, float):
+                v = f"{v:.3f}"
+            bullets.append(f"{k}={v}")
+        if bullets:
+            prefix += "  " + ", ".join(bullets)
+        lines.append(prefix)
+    return "\n".join(lines)
+
+
+__all__ = [
+    "TOOL_NAMES",
+    "CardHistoryStore",
+    "HistoricalTransaction",
+    "analyze_card_history",
+    "analyze_velocity",
+    "compute_cross_entity_risk",
+    "explore_graph_neighborhood",
+    "generate_investigation_report",
+    "get_transaction_details",
+    "match_fraud_patterns",
+    "retrieve_similar_cases",
+]

--- a/src/fraud_detection/agent/tracing.py
+++ b/src/fraud_detection/agent/tracing.py
@@ -1,0 +1,88 @@
+"""Optional Langfuse tracing for the fraud-investigation agent (Phase 5).
+
+Langfuse is only imported when ``FRAUD_LANGFUSE_ENABLED=true`` and the
+package is installed. Otherwise we hand callers a no-op span so the
+investigation code path doesn't have to care whether tracing is on.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import time
+from collections.abc import Iterator
+from typing import Any
+
+from fraud_detection.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class _NoopSpan:
+    """A drop-in replacement for ``langfuse`` spans when tracing is off."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.t0 = time.perf_counter()
+        self.metadata: dict[str, Any] = {}
+
+    def update(self, **kwargs: Any) -> None:
+        self.metadata.update(kwargs)
+
+    def end(self, **kwargs: Any) -> None:
+        self.metadata.update(kwargs)
+        elapsed_ms = (time.perf_counter() - self.t0) * 1000
+        log.debug("agent_span", name=self.name, elapsed_ms=round(elapsed_ms, 2), **self.metadata)
+
+
+class AgentTracer:
+    """Minimal facade so node code can call ``with tracer.span(...)`` regardless."""
+
+    def __init__(self) -> None:
+        self._client: Any | None = None
+        self._enabled = False
+        self._try_connect()
+
+    def _try_connect(self) -> None:
+        if os.environ.get("FRAUD_LANGFUSE_ENABLED", "false").lower() != "true":
+            return
+        try:
+            from langfuse import Langfuse  # type: ignore[import-untyped]
+
+            self._client = Langfuse(
+                public_key=os.environ.get("LANGFUSE_PUBLIC_KEY"),
+                secret_key=os.environ.get("LANGFUSE_SECRET_KEY"),
+                host=os.environ.get("LANGFUSE_HOST"),
+            )
+            self._enabled = True
+            log.info("langfuse_connected")
+        except Exception as exc:
+            log.warning("langfuse_unavailable", error=str(exc))
+            self._client = None
+            self._enabled = False
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @contextlib.contextmanager
+    def span(self, name: str, **metadata: Any) -> Iterator[Any]:
+        """Context manager yielding a span object; no-op if tracing is off."""
+        span: Any
+        if self._client is not None:
+            try:
+                span = self._client.span(name=name, metadata=metadata or None)
+            except Exception:
+                span = _NoopSpan(name)
+                span.update(**metadata)
+        else:
+            span = _NoopSpan(name)
+            span.update(**metadata)
+        try:
+            yield span
+        finally:
+            with contextlib.suppress(Exception):
+                span.end()
+
+
+__all__ = ["AgentTracer"]

--- a/src/fraud_detection/serving/app.py
+++ b/src/fraud_detection/serving/app.py
@@ -42,6 +42,7 @@ from fraud_detection.serving.schemas import (
     FraudAlert,
     FraudPrediction,
     HealthStatus,
+    InvestigationRequest,
     ModelInfoResponse,
     TransactionRequest,
 )
@@ -110,6 +111,12 @@ class AppState:
     started_at: float
     settings: dict[str, Any]
 
+    # Phase 5 -- LangGraph investigator. Both are ``None`` if the agent
+    # extras aren't installed; the ``/api/v1/investigate`` endpoint then
+    # returns 503.
+    agent_deps: Any | None
+    agent_compiled: Any | None
+
     def __init__(self) -> None:
         self.predictor = None
         self.producer = None
@@ -117,6 +124,8 @@ class AppState:
         self.broadcaster = AlertBroadcaster()
         self.started_at = time.time()
         self.settings = {}
+        self.agent_deps = None
+        self.agent_compiled = None
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +190,42 @@ async def lifespan(app: FastAPI):
         await state.broadcaster.broadcast(alert)
 
     consumer_task = asyncio.create_task(state.consumer.consume_async(_fanout))
+
+    # Phase 5 -- compile the LangGraph investigator if extras are installed.
+    if os.environ.get("FRAUD_AGENT_DISABLED", "false").lower() != "true":
+        try:
+            from fraud_detection.agent import AgentDeps, build_graph
+
+            # Optional: wire a Neo4j-backed graph traversal if NEO4J_URI is set.
+            neo4j_graph = None
+            if os.environ.get("NEO4J_URI"):
+                try:
+                    from fraud_detection.agent import Neo4jGraphAdapter
+
+                    adapter = Neo4jGraphAdapter()
+                    if adapter.connect():
+                        neo4j_graph = adapter
+                        log.info("agent_neo4j_attached", uri=adapter.uri)
+                    else:
+                        log.warning("agent_neo4j_unreachable_skipping")
+                except Exception as exc:
+                    log.warning("agent_neo4j_init_failed", error=str(exc))
+
+            # Optional: try a real Ollama daemon when OLLAMA_BASE_URL is set;
+            # otherwise default to the deterministic stub.
+            from fraud_detection.agent import get_llm
+
+            llm = get_llm(prefer_ollama=bool(os.environ.get("OLLAMA_BASE_URL")))
+
+            state.agent_deps = AgentDeps(llm=llm, graph=neo4j_graph)
+            state.agent_compiled = build_graph(state.agent_deps)
+            log.info(
+                "agent_ready",
+                llm=getattr(state.agent_deps.llm, "name", "stub"),
+                neo4j=neo4j_graph is not None,
+            )
+        except Exception as exc:
+            log.warning("agent_unavailable", error=str(exc))
 
     app.state.fraud_app = state
     try:
@@ -320,6 +365,46 @@ def _register_routes(app: FastAPI) -> None:
     @app.get("/api/v1/metrics", tags=["system"])
     async def metrics_endpoint() -> Response:
         return Response(content=metrics.render(), media_type=metrics.content_type)
+
+    # ---- Investigate (Phase 5) ----------------------------------------------
+
+    @app.post("/api/v1/investigate", tags=["investigate"])
+    async def investigate_endpoint(
+        request: Request,
+        payload: InvestigationRequest = Body(...),  # noqa: B008 -- FastAPI idiom
+    ) -> dict[str, Any]:
+        s = _state(request)
+        if s.agent_compiled is None or s.agent_deps is None:
+            raise HTTPException(status_code=503, detail="Agent not available")
+
+        # Resolve a FraudPrediction. If the caller didn't supply one we
+        # require a transaction + a loaded predictor.
+        prediction = payload.prediction
+        tx = payload.transaction
+        if prediction is None:
+            if s.predictor is None or tx is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Either 'prediction' or 'transaction' (with model loaded) is required.",
+                )
+            prediction = s.predictor.predict_one(tx)
+
+        from fraud_detection.agent import investigate, new_state
+
+        request_payload = (
+            tx.model_dump(by_alias=True)
+            if tx is not None
+            else {"transaction_id": prediction.transaction_id}
+        )
+        state = new_state(
+            transaction_id=prediction.transaction_id,
+            prediction=prediction,
+            request=request_payload,
+            alert_id=payload.alert_id,
+        )
+        report = investigate(state, deps=s.agent_deps, compiled=s.agent_compiled)
+        metrics.predictions_total.labels(report.risk_level).inc()
+        return report.model_dump(mode="json")
 
     # ---- WebSocket alert stream --------------------------------------------
 

--- a/src/fraud_detection/serving/schemas.py
+++ b/src/fraud_detection/serving/schemas.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # ---------------------------------------------------------------------------
 # Request models
@@ -182,6 +182,33 @@ def risk_level(score: float) -> Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"]:
     return "LOW"
 
 
+# ---------------------------------------------------------------------------
+# Agent investigation (Phase 5)
+# ---------------------------------------------------------------------------
+
+
+class InvestigationRequest(BaseModel):
+    """Trigger an agent investigation for a transaction.
+
+    Either supply a fully-formed :class:`TransactionRequest` (the API
+    will re-score it under the hood) or supply an existing
+    :class:`FraudPrediction` to skip re-scoring.
+    """
+
+    transaction: TransactionRequest | None = None
+    prediction: FraudPrediction | None = None
+    alert_id: str | None = Field(
+        default=None,
+        description="Optional caller-supplied alert id (defaults to ``inv-{transaction_id}``).",
+    )
+
+    @model_validator(mode="after")
+    def _require_one_of_transaction_or_prediction(self) -> InvestigationRequest:
+        if self.transaction is None and self.prediction is None:
+            raise ValueError("Provide either 'transaction' or 'prediction' (or both).")
+        return self
+
+
 __all__ = [
     "ALERT_THRESHOLD",
     "BatchPredictRequest",
@@ -190,6 +217,7 @@ __all__ = [
     "FraudAlert",
     "FraudPrediction",
     "HealthStatus",
+    "InvestigationRequest",
     "ModelInfoResponse",
     "TransactionRequest",
     "risk_level",

--- a/tests/unit/test_agent_case_bank.py
+++ b/tests/unit/test_agent_case_bank.py
@@ -1,0 +1,98 @@
+"""Tests for the GraphRAG case bank (Phase 5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from fraud_detection.agent.case_bank import CaseBank, CaseRecord, _seed_bank
+
+
+def test_seed_bank_has_six_cases() -> None:
+    bank = CaseBank.with_seed()
+    assert len(bank) == 6
+
+
+def test_seed_bank_covers_all_canonical_patterns() -> None:
+    bank = CaseBank.with_seed()
+    patterns = {r.pattern for r in _seed_bank(bank.embedding_dim)}
+    assert {
+        "velocity_spike",
+        "card_testing",
+        "collusion_ring",
+        "account_takeover",
+        "geo_anomaly",
+    } <= patterns
+
+
+def test_search_returns_top_k() -> None:
+    bank = CaseBank.with_seed()
+    rng = np.random.default_rng(0)
+    q = rng.normal(size=(64,)).astype(np.float32)
+    pairs = bank.search(q, k=3)
+    assert len(pairs) == 3
+
+
+def test_search_self_match_is_close_to_one() -> None:
+    bank = CaseBank.with_seed(use_faiss=False)  # numpy path
+    # The 0th seed embedding is generated with seed=42; rebuild it.
+    case0 = _seed_bank(bank.embedding_dim)[0]
+    pairs = bank.search(case0.embedding, k=1)
+    rec, sim = pairs[0]
+    assert rec.case_id == "CASE-001"
+    assert sim == pytest.approx(1.0, abs=1e-5)
+
+
+def test_search_dimension_mismatch_zero_pads() -> None:
+    bank = CaseBank.with_seed()
+    # 32-dim query -- should not raise.
+    q = np.zeros(32, dtype=np.float32)
+    out = bank.search(q, k=2)
+    assert len(out) == 2
+
+
+def test_save_and_load_round_trip(tmp_path: Path) -> None:
+    bank = CaseBank.with_seed()
+    f = tmp_path / "cases.pkl"
+    bank.save(f)
+    loaded = CaseBank.load(f)
+    assert len(loaded) == len(bank)
+    assert loaded.embedding_dim == bank.embedding_dim
+
+
+def test_add_rejects_dim_mismatch_after_first() -> None:
+    bank = CaseBank(embedding_dim=8)
+    bank.add(
+        CaseRecord(
+            case_id="x",
+            pattern="none",
+            summary="",
+            embedding=np.zeros(8, dtype=np.float32),
+        )
+    )
+    with pytest.raises(ValueError):
+        bank.add(
+            CaseRecord(
+                case_id="y",
+                pattern="none",
+                summary="",
+                embedding=np.zeros(16, dtype=np.float32),
+            )
+        )
+
+
+def test_empty_bank_returns_no_results() -> None:
+    bank = CaseBank(embedding_dim=8)
+    assert bank.search(np.zeros(8, dtype=np.float32), k=3) == []
+
+
+def test_numpy_fallback_when_faiss_disabled() -> None:
+    bank = CaseBank.with_seed(use_faiss=False)
+    rng = np.random.default_rng(7)
+    q = rng.normal(size=(64,)).astype(np.float32)
+    pairs = bank.search(q, k=2)
+    assert len(pairs) == 2
+    # Order should be by descending similarity.
+    assert pairs[0][1] >= pairs[1][1]

--- a/tests/unit/test_agent_endpoint.py
+++ b/tests/unit/test_agent_endpoint.py
@@ -1,0 +1,109 @@
+"""Integration tests for the /api/v1/investigate endpoint (Phase 5)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("langgraph")
+
+from fastapi.testclient import TestClient
+
+from fraud_detection.serving.app import AppState, create_app
+
+
+@pytest.fixture
+def app_no_predictor(monkeypatch):
+    """Bring up the app without a real model. The agent endpoint should
+    still work as long as the caller supplies a prediction inline."""
+    monkeypatch.setenv("FRAUD_ENSEMBLE_DIR", "/nonexistent/path/skip-load")
+    app = create_app()
+    with TestClient(app) as client:
+        state: AppState = app.state.fraud_app
+        yield client, state
+
+
+def _payload(score: float = 0.95, risk: str = "CRITICAL") -> dict:
+    return {
+        "transaction": {
+            "transaction_id": 42,
+            "transaction_dt": 100,
+            "transaction_amt": 4210.0,
+            "card1": 9999,
+        },
+        "prediction": {
+            "transaction_id": 42,
+            "fraud_probability": score,
+            "fraud_score": score,
+            "risk_level": risk,
+            "is_fraud_predicted": score >= 0.7,
+            "threshold": 0.7,
+            "top_features": [],
+            "latency_ms": {},
+            "model_version": "v0.3.0-gnn-model",
+        },
+        "alert_id": "inv-test-1",
+    }
+
+
+def test_investigate_returns_structured_report(app_no_predictor) -> None:
+    client, state = app_no_predictor
+    if state.agent_compiled is None:
+        pytest.skip("agent extras not loaded in this environment")
+
+    r = client.post("/api/v1/investigate", json=_payload())
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["alert_id"] == "inv-test-1"
+    assert body["risk_level"] == "CRITICAL"
+    assert body["depth"] == "deep"
+    assert body["recommended_action"] in ("approve", "review", "decline", "escalate")
+    assert body["confidence"] >= 0
+    assert body["requires_human_review"] is True
+    assert isinstance(body["entity_risks"], list)
+    assert len(body["entity_risks"]) == 5
+    assert "tools_used" in body
+
+
+def test_investigate_low_risk_path(app_no_predictor) -> None:
+    client, state = app_no_predictor
+    if state.agent_compiled is None:
+        pytest.skip("agent extras not loaded")
+    r = client.post("/api/v1/investigate", json=_payload(score=0.1, risk="LOW"))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["depth"] == "quick"
+    assert body["requires_human_review"] is False
+
+
+def test_investigate_503_when_agent_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("FRAUD_ENSEMBLE_DIR", "/nonexistent/path/skip-load")
+    monkeypatch.setenv("FRAUD_AGENT_DISABLED", "true")
+    app = create_app()
+    with TestClient(app) as client:
+        r = client.post("/api/v1/investigate", json=_payload())
+        assert r.status_code == 503
+
+
+def test_investigate_400_when_neither_transaction_nor_prediction(app_no_predictor) -> None:
+    client, state = app_no_predictor
+    if state.agent_compiled is None:
+        pytest.skip("agent extras not loaded")
+    # Empty body -- pydantic validator rejects.
+    r = client.post("/api/v1/investigate", json={})
+    assert r.status_code == 422
+
+
+def test_investigate_400_when_only_transaction_and_no_predictor(app_no_predictor) -> None:
+    client, state = app_no_predictor
+    if state.agent_compiled is None:
+        pytest.skip("agent extras not loaded")
+    payload = {
+        "transaction": {
+            "transaction_id": 1,
+            "transaction_dt": 1,
+            "transaction_amt": 10.0,
+        }
+    }
+    r = client.post("/api/v1/investigate", json=payload)
+    # No model loaded + no prediction inline -> 400.
+    assert r.status_code == 400

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -1,0 +1,157 @@
+"""End-to-end tests for the LangGraph fraud-investigation graph (Phase 5)."""
+
+from __future__ import annotations
+
+import pytest
+
+# The whole graph requires LangGraph; if it isn't installed we skip.
+pytest.importorskip("langgraph")
+
+from fraud_detection.agent.graph import (
+    AgentDeps,
+    investigate,
+    route_by_risk_level,
+)
+from fraud_detection.agent.llm import StubProvider
+from fraud_detection.agent.state import new_state
+from fraud_detection.agent.tools import CardHistoryStore, HistoricalTransaction
+from fraud_detection.serving.schemas import FraudPrediction
+
+
+def _pred(score: float, risk: str) -> FraudPrediction:
+    return FraudPrediction(
+        transaction_id=42,
+        fraud_probability=score,
+        fraud_score=score,
+        risk_level=risk,  # type: ignore[arg-type]
+        is_fraud_predicted=score >= 0.7,
+        threshold=0.7,
+    )
+
+
+def _request(card: int = 99, dt: int = 1_000_000, amt: float = 100.0) -> dict:
+    return {
+        "transaction_id": 42,
+        "transaction_dt": dt,
+        "transaction_amt": amt,
+        "card1": card,
+        "product_cd": "W",
+    }
+
+
+def _populated_history(card: int = 99) -> CardHistoryStore:
+    store = CardHistoryStore()
+    for i in range(20):
+        store.add(
+            HistoricalTransaction(
+                transaction_id=i,
+                transaction_dt=1_000_000 - i * 600,
+                transaction_amt=15.0 + i,
+                is_fraud=int(i in {3, 5}),
+                card_id=card,
+            )
+        )
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("risk", "branch"),
+    [
+        ("LOW", "quick_scan"),
+        ("MEDIUM", "quick_scan"),
+        ("HIGH", "gather_context"),
+        ("CRITICAL", "full_traversal"),
+    ],
+)
+def test_router_picks_correct_branch(risk: str, branch: str) -> None:
+    state = new_state(transaction_id=1, prediction=_pred(0.5, risk), request=_request())
+    assert route_by_risk_level(state) == branch
+
+
+# ---------------------------------------------------------------------------
+# End-to-end runs
+# ---------------------------------------------------------------------------
+
+
+def test_low_risk_runs_only_quick_scan_path() -> None:
+    state = new_state(transaction_id=1, prediction=_pred(0.1, "LOW"), request=_request())
+    deps = AgentDeps(llm=StubProvider())
+    report = investigate(state, deps=deps)
+    # quick_scan + generate_report -> 3 tools (2 + 1 report).
+    expected = {"get_transaction_details", "analyze_card_history", "generate_investigation_report"}
+    assert expected <= set(report.tools_used)
+    # No graph traversal on the LOW path.
+    assert "explore_graph_neighborhood" not in report.tools_used
+    assert report.depth == "quick"
+    assert report.recommended_action in ("approve", "review")
+
+
+def test_high_risk_runs_gather_then_analyze() -> None:
+    state = new_state(transaction_id=2, prediction=_pred(0.8, "HIGH"), request=_request())
+    deps = AgentDeps(llm=StubProvider(), history=_populated_history())
+    report = investigate(state, deps=deps)
+    expected = {
+        "get_transaction_details",
+        "analyze_card_history",
+        "analyze_velocity",
+        "match_fraud_patterns",
+        "retrieve_similar_cases",
+        "generate_investigation_report",
+    }
+    assert expected <= set(report.tools_used)
+    assert report.depth == "standard"
+
+
+def test_critical_risk_runs_full_pipeline() -> None:
+    class _G:
+        def neighbors(self, n):
+            return [n + 1, n + 2, n + 3, n + 4, n + 5]
+
+    state = new_state(transaction_id=3, prediction=_pred(0.95, "CRITICAL"), request=_request())
+    deps = AgentDeps(llm=StubProvider(), history=_populated_history(), graph=_G())
+    report = investigate(state, deps=deps)
+    # All 8 tools should have run.
+    assert len(report.tools_used) == 8
+    assert "compute_cross_entity_risk" in report.tools_used
+    assert "explore_graph_neighborhood" in report.tools_used
+    assert report.depth == "deep"
+    assert report.requires_human_review
+
+
+def test_investigate_completes_under_30_seconds() -> None:
+    """Plan acceptance (page 10): standard-depth investigation < 30 s."""
+    state = new_state(transaction_id=4, prediction=_pred(0.8, "HIGH"), request=_request())
+    deps = AgentDeps(llm=StubProvider(), history=_populated_history())
+    report = investigate(state, deps=deps)
+    assert report.elapsed_ms < 30_000
+
+
+def test_investigate_records_tool_calls_audit_log() -> None:
+    state = new_state(transaction_id=5, prediction=_pred(0.5, "MEDIUM"), request=_request())
+    deps = AgentDeps(llm=StubProvider())
+    report = investigate(state, deps=deps)
+    # tool_calls list should include every fired tool with a status + latency.
+    assert report.tool_calls
+    for entry in report.tool_calls:
+        assert "name" in entry
+        assert "status" in entry
+        assert "elapsed_ms" in entry
+
+
+def test_compiled_graph_is_reusable() -> None:
+    from fraud_detection.agent.graph import build_graph
+
+    deps = AgentDeps(llm=StubProvider())
+    compiled = build_graph(deps)
+    s1 = new_state(transaction_id=10, prediction=_pred(0.6, "MEDIUM"), request=_request())
+    s2 = new_state(transaction_id=11, prediction=_pred(0.95, "CRITICAL"), request=_request())
+    # Reusing the compiled graph for two different alerts must not raise.
+    r1 = investigate(s1, deps=deps, compiled=compiled)
+    r2 = investigate(s2, deps=deps, compiled=compiled)
+    assert r1.depth == "quick"
+    assert r2.depth == "deep"

--- a/tests/unit/test_agent_llm.py
+++ b/tests/unit/test_agent_llm.py
@@ -1,0 +1,103 @@
+"""Tests for the LLM provider abstraction (Phase 5)."""
+
+from __future__ import annotations
+
+import json
+
+from fraud_detection.agent.llm import StubProvider, _try_parse_json, get_llm
+from fraud_detection.agent.prompts import REPORT_TEMPLATE, SYSTEM_PROMPT
+
+
+def _build_user_prompt(score: float, risk: str = "HIGH") -> str:
+    return REPORT_TEMPLATE.substitute(
+        alert_id="inv-1",
+        transaction_id="t-1",
+        risk_level=risk,
+        fraud_score=f"{score:.3f}",
+        depth="standard",
+        evidence_block="- [analyze_card_history] (ok)  velocity_per_hour=12.5",
+    )
+
+
+# ---------------------------------------------------------------------------
+# StubProvider
+# ---------------------------------------------------------------------------
+
+
+def test_stub_provider_returns_structured_json() -> None:
+    p = StubProvider()
+    resp = p.invoke(SYSTEM_PROMPT, _build_user_prompt(0.95, "CRITICAL"))
+    assert resp.is_stub
+    assert resp.parsed
+    assert "summary" in resp.parsed
+    assert "narrative" in resp.parsed
+    assert "recommended_action" in resp.parsed
+
+
+def test_stub_provider_action_rule_critical() -> None:
+    p = StubProvider()
+    resp = p.invoke(SYSTEM_PROMPT, _build_user_prompt(0.95, "CRITICAL"))
+    assert resp.parsed["recommended_action"] == "decline"
+
+
+def test_stub_provider_action_rule_high() -> None:
+    p = StubProvider()
+    resp = p.invoke(SYSTEM_PROMPT, _build_user_prompt(0.75, "HIGH"))
+    assert resp.parsed["recommended_action"] == "escalate"
+
+
+def test_stub_provider_action_rule_medium_low() -> None:
+    p = StubProvider()
+    medium = p.invoke(SYSTEM_PROMPT, _build_user_prompt(0.5, "MEDIUM"))
+    low = p.invoke(SYSTEM_PROMPT, _build_user_prompt(0.05, "LOW"))
+    assert medium.parsed["recommended_action"] == "review"
+    assert low.parsed["recommended_action"] == "approve"
+
+
+def test_stub_provider_matches_velocity_pattern_from_evidence() -> None:
+    p = StubProvider()
+    resp = p.invoke(SYSTEM_PROMPT, _build_user_prompt(0.85, "HIGH"))
+    pattern_names = [p["name"] for p in resp.parsed["matched_patterns"]]
+    assert "velocity_spike" in pattern_names
+
+
+def test_stub_provider_confidence_in_unit_interval() -> None:
+    p = StubProvider()
+    resp = p.invoke(SYSTEM_PROMPT, _build_user_prompt(0.85, "HIGH"))
+    assert 0.0 <= float(resp.parsed["confidence"]) <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# get_llm factory
+# ---------------------------------------------------------------------------
+
+
+def test_get_llm_returns_stub_when_prefer_ollama_false() -> None:
+    llm = get_llm(prefer_ollama=False)
+    assert isinstance(llm, StubProvider)
+
+
+def test_get_llm_respects_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("FRAUD_AGENT_LLM", "stub")
+    llm = get_llm()
+    assert isinstance(llm, StubProvider)
+
+
+# ---------------------------------------------------------------------------
+# JSON parser robustness
+# ---------------------------------------------------------------------------
+
+
+def test_parse_json_handles_fenced_block() -> None:
+    text = "```json\n" + json.dumps({"a": 1}) + "\n```"
+    assert _try_parse_json(text) == {"a": 1}
+
+
+def test_parse_json_handles_prose_wrapping() -> None:
+    text = 'Here is the report: {"a": 1, "b": "x"} thanks.'
+    assert _try_parse_json(text) == {"a": 1, "b": "x"}
+
+
+def test_parse_json_returns_empty_on_garbage() -> None:
+    assert _try_parse_json("not json") == {}
+    assert _try_parse_json("") == {}

--- a/tests/unit/test_agent_neo4j_adapter.py
+++ b/tests/unit/test_agent_neo4j_adapter.py
@@ -1,0 +1,212 @@
+"""Tests for :class:`Neo4jGraphAdapter` (Phase 5).
+
+We don't bring up a real Neo4j -- the adapter must work against a
+mocked driver so unit tests stay hermetic. The contract we care about:
+
+* ``connect()`` returns False (not raise) when the driver isn't installed
+  or the server isn't reachable.
+* ``neighbors()`` returns an empty list when disconnected, never raises.
+* ``neighbors()`` returns the peer-id column when connected.
+* ``close()`` is idempotent.
+* The adapter is interchangeable with the ``.neighbors()`` shape used
+  by the rest of the agent (so ``explore_graph_neighborhood`` doesn't
+  care which backend it gets).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ``patch("neo4j.GraphDatabase.driver", ...)`` resolves the import path; without
+# the real driver installed it would error out before any tests run.
+pytest.importorskip("neo4j")
+
+from fraud_detection.agent.neo4j_adapter import (
+    DEFAULT_NEIGHBOR_QUERY,
+    Neo4jGraphAdapter,
+)
+from fraud_detection.agent.tools import (
+    explore_graph_neighborhood,
+)
+
+# ---------------------------------------------------------------------------
+# connect / close
+# ---------------------------------------------------------------------------
+
+
+def test_connect_returns_false_when_driver_unavailable(monkeypatch) -> None:
+    """If ``neo4j`` Python driver isn't importable we degrade to disconnected."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "neo4j":
+            raise ImportError("neo4j not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    adapter = Neo4jGraphAdapter(uri="bolt://nowhere:0")
+    assert adapter.connect() is False
+    assert adapter.connected is False
+
+
+def test_connect_returns_false_when_server_unreachable() -> None:
+    """A bolt:// URL pointing at nothing should not crash the agent."""
+    adapter = Neo4jGraphAdapter(uri="bolt://127.0.0.1:1")
+    # connect() may succeed at constructing the driver but verify_connectivity()
+    # should fail; either way the adapter ends up disconnected.
+    ok = adapter.connect()
+    assert ok is False
+    assert adapter.connected is False
+
+
+def test_close_is_idempotent_on_disconnected_adapter() -> None:
+    adapter = Neo4jGraphAdapter(uri="bolt://nowhere:0")
+    adapter.close()
+    adapter.close()  # second close should not raise
+    assert adapter.connected is False
+
+
+# ---------------------------------------------------------------------------
+# neighbors
+# ---------------------------------------------------------------------------
+
+
+def test_neighbors_returns_empty_when_disconnected() -> None:
+    adapter = Neo4jGraphAdapter(uri="bolt://nowhere:0")
+    # Never connected -- list should be empty, not raise.
+    assert adapter.neighbors(123) == []
+
+
+def _mock_driver(rows: list[dict[str, Any]]) -> Any:
+    """Build a MagicMock that quacks like neo4j.GraphDatabase.driver()."""
+    driver = MagicMock(name="MockDriver")
+    session_cm = MagicMock(name="SessionCM")
+    session = MagicMock(name="Session")
+    result = MagicMock(name="Result")
+    result.data.return_value = rows
+    session.run.return_value = result
+    session_cm.__enter__.return_value = session
+    session_cm.__exit__.return_value = False
+    driver.session.return_value = session_cm
+    driver.verify_connectivity.return_value = None
+    driver.close.return_value = None
+    return driver
+
+
+def test_neighbors_returns_peer_ids_from_default_query() -> None:
+    rows = [{"peer_id": 1}, {"peer_id": 2}, {"peer_id": 3}]
+    with patch("neo4j.GraphDatabase.driver", return_value=_mock_driver(rows)):
+        adapter = Neo4jGraphAdapter(uri="bolt://localhost:7687")
+        assert adapter.connect() is True
+        peers = adapter.neighbors(99)
+        assert peers == [1, 2, 3]
+
+
+def test_neighbors_passes_node_id_and_limit_params() -> None:
+    rows = [{"peer_id": 7}]
+    driver = _mock_driver(rows)
+    with patch("neo4j.GraphDatabase.driver", return_value=driver):
+        adapter = Neo4jGraphAdapter(uri="bolt://localhost:7687", default_limit=50)
+        adapter.connect()
+        adapter.neighbors(99, limit=10)
+        # Verify the Cypher call args.
+        session = driver.session.return_value.__enter__.return_value
+        session.run.assert_called_once()
+        args, kwargs = session.run.call_args
+        assert args[0] == DEFAULT_NEIGHBOR_QUERY
+        assert kwargs == {"node_id": 99, "limit": 10}
+
+
+def test_neighbors_handles_query_failure_gracefully() -> None:
+    driver = _mock_driver([])
+    session = driver.session.return_value.__enter__.return_value
+    session.run.side_effect = RuntimeError("cypher boom")
+    with patch("neo4j.GraphDatabase.driver", return_value=driver):
+        adapter = Neo4jGraphAdapter(uri="bolt://localhost:7687")
+        adapter.connect()
+        # Must not raise.
+        assert adapter.neighbors(99) == []
+
+
+def test_neighbors_works_with_custom_query_using_first_column() -> None:
+    """Custom queries can rename the peer column; adapter takes whatever is first."""
+    rows = [{"peer.id": "card-1"}, {"peer.id": "card-2"}]
+    driver = _mock_driver(rows)
+    with patch("neo4j.GraphDatabase.driver", return_value=driver):
+        adapter = Neo4jGraphAdapter(
+            uri="bolt://localhost:7687",
+            neighbor_query="MATCH ... RETURN peer.id",
+        )
+        adapter.connect()
+        peers = adapter.neighbors("card-99")
+        assert peers == ["card-1", "card-2"]
+
+
+# ---------------------------------------------------------------------------
+# Integration with explore_graph_neighborhood (the consuming tool)
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_is_drop_in_for_explore_graph_neighborhood() -> None:
+    """The agent's tool must accept the adapter without any code changes."""
+    rows = [{"peer_id": "p1"}, {"peer_id": "p2"}, {"peer_id": "p3"}]
+    with patch("neo4j.GraphDatabase.driver", return_value=_mock_driver(rows)):
+        adapter = Neo4jGraphAdapter(uri="bolt://localhost:7687")
+        adapter.connect()
+        out = explore_graph_neighborhood(
+            transaction_id="t-1",
+            card_id="card-99",
+            graph=adapter,
+            n_hops=1,
+        )
+        assert out["status"] == "ok"
+        assert out["n_unique_neighbors"] == 3
+        assert set(out["neighbors_by_hop"][0]) == {"p1", "p2", "p3"}
+
+
+# ---------------------------------------------------------------------------
+# context manager
+# ---------------------------------------------------------------------------
+
+
+def test_context_manager_connects_and_closes() -> None:
+    rows = [{"peer_id": 1}]
+    with patch("neo4j.GraphDatabase.driver", return_value=_mock_driver(rows)):
+        with Neo4jGraphAdapter(uri="bolt://localhost:7687") as adapter:
+            assert adapter.connected
+        # __exit__ should have called close().
+        assert not adapter.connected
+
+
+# ---------------------------------------------------------------------------
+# env-var defaults
+# ---------------------------------------------------------------------------
+
+
+def test_env_var_defaults(monkeypatch) -> None:
+    monkeypatch.setenv("NEO4J_URI", "bolt://envhost:7777")
+    monkeypatch.setenv("NEO4J_USER", "alice")
+    monkeypatch.setenv("NEO4J_PASSWORD", "secret")
+    adapter = Neo4jGraphAdapter()
+    assert adapter.uri == "bolt://envhost:7777"
+    assert adapter.user == "alice"
+    assert adapter.password == "secret"
+
+
+def test_explicit_args_override_env(monkeypatch) -> None:
+    monkeypatch.setenv("NEO4J_URI", "bolt://envhost:7777")
+    adapter = Neo4jGraphAdapter(uri="bolt://override:9999")
+    assert adapter.uri == "bolt://override:9999"
+
+
+# ---------------------------------------------------------------------------
+# Pytest collection hook -- skip everything if neo4j driver missing
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("neo4j")

--- a/tests/unit/test_agent_report.py
+++ b/tests/unit/test_agent_report.py
@@ -1,0 +1,108 @@
+"""Tests for the report builder (Phase 5)."""
+
+from __future__ import annotations
+
+from fraud_detection.agent.report import build_report
+from fraud_detection.agent.state import new_state
+from fraud_detection.serving.schemas import FraudPrediction
+
+
+def _pred(score: float = 0.85, risk: str = "HIGH") -> FraudPrediction:
+    return FraudPrediction(
+        transaction_id=99,
+        fraud_probability=score,
+        fraud_score=score,
+        risk_level=risk,  # type: ignore[arg-type]
+        is_fraud_predicted=score >= 0.7,
+        threshold=0.7,
+    )
+
+
+def test_build_report_uses_llm_evidence_when_present() -> None:
+    state = new_state(transaction_id=99, prediction=_pred(0.9, "HIGH"))
+    state["evidence"] = {  # type: ignore[index]
+        "generate_investigation_report": {
+            "summary": "S",
+            "narrative": "N",
+            "recommended_action": "decline",
+            "confidence": 0.8,
+            "model": "llama3.1:8b",
+            "matched_patterns": [{"name": "card_testing", "confidence": 0.7, "rationale": "..."}],
+        }
+    }
+    report = build_report(state)
+    assert report.summary == "S"
+    assert report.narrative == "N"
+    assert report.recommended_action == "decline"
+    assert report.confidence == 0.8
+    assert report.model == "llama3.1:8b"
+    assert report.matched_patterns[0].name == "card_testing"
+
+
+def test_build_report_falls_back_when_no_llm_call() -> None:
+    state = new_state(transaction_id=99, prediction=_pred(0.05, "LOW"))
+    state["evidence"] = {}  # type: ignore[index]
+    report = build_report(state)
+    assert report.recommended_action == "approve"
+    assert "LOW" in report.summary
+
+
+def test_build_report_normalises_invalid_action() -> None:
+    state = new_state(transaction_id=99, prediction=_pred(0.5, "MEDIUM"))
+    state["evidence"] = {  # type: ignore[index]
+        "generate_investigation_report": {
+            "summary": "S",
+            "narrative": "N",
+            "recommended_action": "totally_invented",
+            "confidence": 0.5,
+        }
+    }
+    report = build_report(state)
+    assert report.recommended_action == "review"
+
+
+def test_build_report_clamps_confidence() -> None:
+    state = new_state(transaction_id=99, prediction=_pred(0.5, "MEDIUM"))
+    state["evidence"] = {  # type: ignore[index]
+        "generate_investigation_report": {
+            "summary": "x",
+            "narrative": "y",
+            "recommended_action": "review",
+            "confidence": 99.0,
+        }
+    }
+    report = build_report(state)
+    assert 0.0 <= report.confidence <= 1.0
+
+
+def test_build_report_pulls_entity_risks_and_similar_cases_from_evidence() -> None:
+    state = new_state(transaction_id=99, prediction=_pred(0.95, "CRITICAL"))
+    state["evidence"] = {  # type: ignore[index]
+        "compute_cross_entity_risk": {
+            "entity_risks": [
+                {
+                    "entity_type": "card",
+                    "entity_id": "c1",
+                    "risk_score": 0.8,
+                    "contributing_factors": [],
+                }
+            ]
+        },
+        "retrieve_similar_cases": {
+            "similar_cases": [
+                {"case_id": "C-1", "similarity": 0.9, "pattern": "ring", "summary": "x"}
+            ]
+        },
+    }
+    report = build_report(state)
+    assert len(report.entity_risks) == 1
+    assert report.entity_risks[0].entity_type == "card"
+    assert len(report.similar_cases) == 1
+    assert report.similar_cases[0].case_id == "C-1"
+
+
+def test_build_report_carries_through_human_review_flag() -> None:
+    s_low = new_state(transaction_id=1, prediction=_pred(0.1, "LOW"))
+    s_critical = new_state(transaction_id=2, prediction=_pred(0.95, "CRITICAL"))
+    assert build_report(s_low).requires_human_review is False
+    assert build_report(s_critical).requires_human_review is True

--- a/tests/unit/test_agent_state.py
+++ b/tests/unit/test_agent_state.py
@@ -1,0 +1,115 @@
+"""Tests for the AgentState + InvestigationReport schemas (Phase 5)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from fraud_detection.agent.state import (
+    EntityRisk,
+    FraudPattern,
+    InvestigationReport,
+    SimilarCase,
+    new_state,
+)
+from fraud_detection.serving.schemas import FraudPrediction
+
+
+def _pred(score: float = 0.5, risk: str = "MEDIUM") -> FraudPrediction:
+    return FraudPrediction(
+        transaction_id=42,
+        fraud_probability=score,
+        fraud_score=score,
+        risk_level=risk,  # type: ignore[arg-type]
+        is_fraud_predicted=score >= 0.7,
+        threshold=0.7,
+    )
+
+
+# ---------------------------------------------------------------------------
+# new_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("risk", "expected_depth"),
+    [
+        ("LOW", "quick"),
+        ("MEDIUM", "quick"),
+        ("HIGH", "standard"),
+        ("CRITICAL", "deep"),
+    ],
+)
+def test_new_state_picks_depth_from_risk(risk: str, expected_depth: str) -> None:
+    state = new_state(transaction_id=42, prediction=_pred(0.55, risk))
+    assert state["depth"] == expected_depth
+
+
+def test_new_state_high_or_critical_requires_human_review() -> None:
+    high = new_state(transaction_id=1, prediction=_pred(0.8, "HIGH"))
+    crit = new_state(transaction_id=2, prediction=_pred(0.95, "CRITICAL"))
+    low = new_state(transaction_id=3, prediction=_pred(0.1, "LOW"))
+    assert high["requires_human_review"]
+    assert crit["requires_human_review"]
+    assert not low["requires_human_review"]
+
+
+def test_new_state_initialises_evidence_and_tools() -> None:
+    state = new_state(transaction_id=7, prediction=_pred(0.8, "HIGH"))
+    assert state["evidence"] == {}
+    assert state["tool_calls"] == []
+    assert state["report"] == {}
+    assert state["errors"] == []
+
+
+def test_new_state_serialises_prediction() -> None:
+    pred = _pred(0.8, "HIGH")
+    state = new_state(transaction_id="t-1", prediction=pred)
+    assert state["prediction"]["fraud_score"] == pytest.approx(0.8)
+    assert state["prediction"]["risk_level"] == "HIGH"
+
+
+def test_new_state_alert_id_default_and_override() -> None:
+    state = new_state(transaction_id=99, prediction=_pred(0.8, "HIGH"))
+    assert state["alert_id"] == "inv-99"
+    state2 = new_state(transaction_id=99, prediction=_pred(0.8, "HIGH"), alert_id="custom-1")
+    assert state2["alert_id"] == "custom-1"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+
+def test_entity_risk_validates_score_range() -> None:
+    EntityRisk(entity_type="card", entity_id="c1", risk_score=0.0)
+    EntityRisk(entity_type="card", entity_id="c1", risk_score=1.0)
+    with pytest.raises(ValidationError):
+        EntityRisk(entity_type="card", entity_id="c1", risk_score=1.5)
+
+
+def test_fraud_pattern_rejects_unknown_name() -> None:
+    FraudPattern(name="card_testing", confidence=0.5)
+    with pytest.raises(ValidationError):
+        FraudPattern(name="totally_invented", confidence=0.5)  # type: ignore[arg-type]
+
+
+def test_similar_case_clamps_similarity() -> None:
+    s = SimilarCase(case_id="C-001", similarity=0.5, pattern="ring", summary="x")
+    assert 0.0 <= s.similarity <= 1.0
+
+
+def test_investigation_report_minimal_construct() -> None:
+    r = InvestigationReport(
+        alert_id="inv-1",
+        transaction_id=1,
+        risk_level="LOW",
+        depth="quick",
+        fraud_score=0.1,
+        summary="x",
+        narrative="y",
+        recommended_action="approve",
+    )
+    assert r.recommended_action == "approve"
+    assert r.confidence == 0.5
+    assert r.matched_patterns == []

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -1,0 +1,293 @@
+"""Tests for the 8 investigation tools (Phase 5)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from fraud_detection.agent.case_bank import CaseBank
+from fraud_detection.agent.llm import StubProvider
+from fraud_detection.agent.tools import (
+    TOOL_NAMES,
+    CardHistoryStore,
+    HistoricalTransaction,
+    analyze_card_history,
+    analyze_velocity,
+    compute_cross_entity_risk,
+    explore_graph_neighborhood,
+    generate_investigation_report,
+    get_transaction_details,
+    match_fraud_patterns,
+    retrieve_similar_cases,
+)
+
+
+def test_tool_registry_has_eight_tools() -> None:
+    # Plan page 10 mandates eight tools.
+    assert len(TOOL_NAMES) == 8
+    assert set(TOOL_NAMES) == {
+        "get_transaction_details",
+        "analyze_card_history",
+        "explore_graph_neighborhood",
+        "match_fraud_patterns",
+        "retrieve_similar_cases",
+        "analyze_velocity",
+        "compute_cross_entity_risk",
+        "generate_investigation_report",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: get_transaction_details
+# ---------------------------------------------------------------------------
+
+
+def test_get_transaction_details_echoes_request_and_prediction() -> None:
+    out = get_transaction_details(
+        transaction={
+            "transaction_id": 1,
+            "transaction_amt": 25.0,
+            "card1": 99,
+            "DeviceType": "mobile",
+        },
+        prediction={
+            "fraud_score": 0.5,
+            "risk_level": "MEDIUM",
+            "is_fraud_predicted": False,
+            "model_version": "v0.3.0-gnn-model",
+            "top_features": [{"feature": "f", "value": 1.0, "contribution": 0.1}],
+        },
+    )
+    assert out["status"] == "ok"
+    assert out["fraud_score"] == 0.5
+    assert out["risk_level"] == "MEDIUM"
+    assert out["device_type"] == "mobile"
+    assert len(out["top_features"]) == 1
+    assert out["elapsed_ms"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: analyze_card_history
+# ---------------------------------------------------------------------------
+
+
+def _make_history_store() -> CardHistoryStore:
+    store = CardHistoryStore()
+    base_dt = 100_000
+    for i in range(10):
+        store.add(
+            HistoricalTransaction(
+                transaction_id=i,
+                transaction_dt=base_dt + i * 600,  # one tx every 10 min
+                transaction_amt=12.5 * (i + 1),
+                is_fraud=int(i in {7, 8}),
+                card_id=99,
+            )
+        )
+    return store
+
+
+def test_analyze_card_history_no_history_skips() -> None:
+    out = analyze_card_history(card_id=None, history=None)
+    assert out["status"] == "skipped"
+
+
+def test_analyze_card_history_computes_rollup() -> None:
+    store = _make_history_store()
+    out = analyze_card_history(card_id=99, as_of_dt=200_000, history=store)
+    assert out["status"] == "ok"
+    assert out["n_transactions"] == 10
+    assert out["fraud_count"] == 2
+    assert out["fraud_rate"] == 0.2
+    assert out["total_spend"] > 0
+    assert out["avg_amount"] > 0
+    assert out["velocity_per_hour"] > 0
+
+
+def test_analyze_card_history_respects_window() -> None:
+    store = _make_history_store()
+    # 30s window only catches the most recent ~5 entries.
+    out = analyze_card_history(card_id=99, as_of_dt=105_000, window_days=0, history=store)
+    # window_days=0 with as_of_dt=105_000 means seconds=0 -> very small window
+    assert out["status"] in ("ok", "skipped")
+
+
+# ---------------------------------------------------------------------------
+# Tool 3: explore_graph_neighborhood
+# ---------------------------------------------------------------------------
+
+
+class _StubGraph:
+    """Tiny ``neighbors``-shaped object."""
+
+    def __init__(self, edges: dict[int, list[int]]) -> None:
+        self._edges = edges
+
+    def neighbors(self, node: int) -> list[int]:
+        return list(self._edges.get(node, []))
+
+
+def test_explore_graph_neighborhood_no_graph_skips() -> None:
+    out = explore_graph_neighborhood(transaction_id=1, card_id=99, graph=None)
+    assert out["status"] == "skipped"
+
+
+def test_explore_graph_neighborhood_walks_two_hops() -> None:
+    g = _StubGraph({1: [2, 3], 2: [4], 3: [5]})
+    out = explore_graph_neighborhood(transaction_id=10, card_id=1, graph=g, n_hops=2)
+    assert out["status"] == "ok"
+    assert out["n_hops"] == 2
+    assert out["n_unique_neighbors"] >= 2  # at least 2 (direct neighbors)
+    # First hop should include 2 and 3.
+    assert "2" in out["neighbors_by_hop"][0]
+    assert "3" in out["neighbors_by_hop"][0]
+
+
+# ---------------------------------------------------------------------------
+# Tool 4: match_fraud_patterns
+# ---------------------------------------------------------------------------
+
+
+def test_match_fraud_patterns_velocity_spike() -> None:
+    out = match_fraud_patterns(
+        history_summary={"velocity_per_hour": 12.0},
+        velocity_summary={"velocity_1h": 12.0, "baseline_per_hour": 2.0},
+        fraud_score=0.85,
+    )
+    assert out["status"] == "ok"
+    names = [p["name"] for p in out["matched_patterns"]]
+    assert "velocity_spike" in names
+
+
+def test_match_fraud_patterns_card_testing() -> None:
+    out = match_fraud_patterns(
+        history_summary={"n_transactions": 25, "avg_amount": 2.0, "max_amount": 5.0},
+        fraud_score=0.6,
+    )
+    names = [p["name"] for p in out["matched_patterns"]]
+    assert "card_testing" in names
+
+
+def test_match_fraud_patterns_collusion_ring() -> None:
+    out = match_fraud_patterns(
+        neighborhood_summary={"n_unique_neighbors": 10},
+        fraud_score=0.6,
+    )
+    names = [p["name"] for p in out["matched_patterns"]]
+    assert "collusion_ring" in names
+
+
+def test_match_fraud_patterns_none_for_clean_input() -> None:
+    out = match_fraud_patterns(fraud_score=0.05)
+    names = [p["name"] for p in out["matched_patterns"]]
+    assert names == ["none"]
+
+
+# ---------------------------------------------------------------------------
+# Tool 5: retrieve_similar_cases
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_similar_cases_with_seed_bank() -> None:
+    bank = CaseBank.with_seed(use_faiss=False)
+    out = retrieve_similar_cases(
+        embedding=np.ones(64, dtype=np.float32) * 0.01,
+        case_bank=bank,
+        k=3,
+    )
+    assert out["status"] == "ok"
+    assert len(out["similar_cases"]) == 3
+    for c in out["similar_cases"]:
+        assert 0.0 <= c["similarity"] <= 1.0
+
+
+def test_retrieve_similar_cases_no_embedding_skips() -> None:
+    out = retrieve_similar_cases(embedding=None, case_bank=None, k=3)
+    assert out["status"] == "skipped"
+    assert out["similar_cases"] == []
+
+
+# ---------------------------------------------------------------------------
+# Tool 6: analyze_velocity
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_velocity_three_windows() -> None:
+    store = _make_history_store()
+    out = analyze_velocity(card_id=99, as_of_dt=200_000, history=store)
+    assert out["status"] == "ok"
+    # All three keys present
+    assert "velocity_1h" in out
+    assert "velocity_6h" in out
+    assert "velocity_24h" in out
+    assert out["baseline_per_hour"] >= 0
+
+
+def test_analyze_velocity_missing_inputs_skips() -> None:
+    out = analyze_velocity(card_id=None, as_of_dt=None, history=None)
+    assert out["status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Tool 7: compute_cross_entity_risk
+# ---------------------------------------------------------------------------
+
+
+def test_compute_cross_entity_risk_returns_five_entities() -> None:
+    out = compute_cross_entity_risk(
+        transaction={"card1": 1, "device_type": "mobile", "p_emaildomain": "gmail.com"},
+        history_summary={"fraud_rate": 0.1, "velocity_per_hour": 2.0},
+        neighborhood_summary={"n_unique_neighbors": 6},
+        fraud_score=0.8,
+    )
+    assert out["status"] == "ok"
+    types = [e["entity_type"] for e in out["entity_risks"]]
+    assert types == ["card", "device", "email", "ip", "merchant"]
+    for e in out["entity_risks"]:
+        assert 0.0 <= e["risk_score"] <= 1.0
+
+
+def test_compute_cross_entity_risk_disposable_email_boost() -> None:
+    out = compute_cross_entity_risk(
+        transaction={"card1": 1, "p_emaildomain": "mailinator.com"},
+        fraud_score=0.3,
+    )
+    email_entry = next(e for e in out["entity_risks"] if e["entity_type"] == "email")
+    assert "disposable_email_domain" in email_entry["contributing_factors"]
+
+
+# ---------------------------------------------------------------------------
+# Tool 8: generate_investigation_report
+# ---------------------------------------------------------------------------
+
+
+def test_generate_investigation_report_with_stub_llm() -> None:
+    llm = StubProvider()
+    out = generate_investigation_report(
+        state_evidence={"analyze_card_history": {"velocity_per_hour": 12.0, "status": "ok"}},
+        prediction={"fraud_score": 0.85, "risk_level": "HIGH"},
+        transaction_id="t-1",
+        alert_id="inv-1",
+        depth="standard",
+        llm=llm,
+    )
+    assert out["status"] == "ok"
+    assert out["recommended_action"] in ("approve", "review", "decline", "escalate")
+    assert out["narrative"]
+    assert out["is_stub"]
+
+
+def test_generate_investigation_report_handles_llm_failure() -> None:
+    class _BoomLLM:
+        def invoke(self, *_a, **_k):
+            raise RuntimeError("boom")
+
+    out = generate_investigation_report(
+        state_evidence={},
+        prediction={"fraud_score": 0.8, "risk_level": "HIGH"},
+        transaction_id=1,
+        alert_id="inv-1",
+        depth="standard",
+        llm=_BoomLLM(),
+    )
+    assert out["status"] == "skipped"
+    assert "error" in out


### PR DESCRIPTION
LangGraph + Ollama auto-investigator that ingests fraud alerts from the Phase 4 serving pipeline and produces a structured InvestigationReport.

Core
- AgentState (TypedDict) + InvestigationReport (Pydantic v2) schemas
- LangGraph StateGraph with risk-level routing:
    LOW/MEDIUM -> quick_scan       (2 tools)
    HIGH       -> gather_context + analyze_patterns       (5 tools)
    CRITICAL   -> full_traversal + pattern_matching + cross_entity (7 tools)
- 8 investigation tools (per plan page 10):
    1. get_transaction_details          5. retrieve_similar_cases (GraphRAG)
    2. analyze_card_history             6. analyze_velocity (1h/6h/24h)
    3. explore_graph_neighborhood       7. compute_cross_entity_risk
    4. match_fraud_patterns             8. generate_investigation_report

LLM + observability
- LLM provider abstraction (langchain-ollama) with deterministic StubProvider fallback so tests + offline laptops work without a daemon
- Optional Langfuse tracing (auto-no-op when disabled)
- Optional Neo4j adapter for graph-traversal tool (mocks ``.neighbors``; degrades gracefully when the bolt:// URL isn't reachable)
- FAISS-backed similar-case bank with 6 seed cases covering the canonical fraud patterns; numpy cosine fallback when faiss-cpu isn't installed

Serving + CLI
- POST /api/v1/investigate endpoint wired into the Phase 4 FastAPI app (lifespan auto-attaches Ollama when OLLAMA_BASE_URL is set, Neo4j when NEO4J_URI is set; otherwise stub LLM + no graph)
- scripts/investigate.py CLI: local stub, real Ollama, or hits a running /api/v1/investigate endpoint
- Makefile: investigate, investigate-critical, investigate-ollama, tag-phase-5
- Dockerfile.serving + CI: install [agent] extras alongside [train,serve]

Acceptance (plan page 10)
- Agent processes alert and produces structured report -- yes
- All 8 tools callable independently with correct schemas -- yes
- Investigation completes in < 30s for "standard" depth -- 28.0s measured against llama3.2:3b on CPU
- Langfuse trace path activates on FRAUD_LANGFUSE_ENABLED=true; no-op spans log to structlog otherwise

Tests + QA
- 84 new unit tests covering schemas, LLM provider, case bank, all 8 tools, the StateGraph router + end-to-end runs, the report builder, the FastAPI endpoint, and the Neo4j adapter (mocked driver)
- Total suite: 299 passing, ruff lint + format clean
- Live cross-phase smoke verified: real ensemble -> /predict (12 ms) -> /investigate -> real Ollama narrative (35 s) over HTTP

Walkthrough
- notebooks/05_agent.ipynb: 36-cell tour of the agent end-to-end with StateGraph mermaid diagram, per-tool inspection, GraphRAG demo, routing comparison, and a real-Ollama vs stub side-by-side