### PR TITLE
feat(phase-7): MLOps & monitoring (v0.7.0-mlops)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint-and-test:
-    name: Lint + unit tests
+    name: Python lint + tests (Py ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -26,17 +26,19 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - name: Install package (dev + train + serve + agent extras, CPU-only torch)
+      - name: Install package (dev + train + serve + agent + monitor extras, CPU-only torch)
         # The ``train`` extras pull in PyTorch. By default pip picks the
         # CUDA wheel which is ~2GB; we want the CPU wheel for CI speed.
         # ``serve`` adds Ray Serve, confluent-kafka, SHAP, prometheus-client
         # and websockets so the Phase 4 serving tests can import them.
         # ``agent`` adds LangGraph, LangChain, langchain-ollama, langfuse,
-        # faiss-cpu and neo4j for the Phase 5 investigator.
+        # faiss-cpu and neo4j for the Phase 5 investigator. ``monitor``
+        # pulls in Evidently + prometheus-client for the Phase 7 drift
+        # and monitoring tests.
         run: |
           python -m pip install --upgrade pip
           pip install --extra-index-url https://download.pytorch.org/whl/cpu "torch>=2.10,<2.11"
-          pip install -e ".[dev,train,serve,agent]"
+          pip install -e ".[dev,train,serve,agent,monitor]"
 
       - name: Lint (ruff)
         run: |
@@ -53,3 +55,100 @@ jobs:
         with:
           name: coverage-xml
           path: coverage.xml
+
+  dashboard:
+    name: Dashboard lint + tests (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22"]
+    # The dashboard is a Phase 6 deliverable but its CI job lands in Phase 7
+    # alongside the rest of the MLOps surface.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install dashboard dependencies
+        working-directory: dashboard
+        run: npm ci || npm install
+
+      - name: Type-check
+        working-directory: dashboard
+        run: npx tsc -b
+
+      - name: Vitest
+        working-directory: dashboard
+        run: npm test -- --run
+
+      - name: Production build
+        working-directory: dashboard
+        run: npm run build
+
+  integration:
+    name: Integration tests (Docker compose smoke)
+    runs-on: ubuntu-latest
+    needs: lint-and-test
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install integration deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install --extra-index-url https://download.pytorch.org/whl/cpu "torch>=2.10,<2.11"
+          pip install -e ".[dev,serve,monitor]"
+
+      - name: Validate Prometheus rules
+        uses: docker://prom/prometheus:v2.55.1
+        with:
+          args: promtool check rules /github/workspace/configs/prometheus_rules.yml
+
+      - name: Validate Grafana dashboards (JSON parse)
+        run: |
+          python - <<'PY'
+          import json, pathlib, sys
+          ok = True
+          for p in pathlib.Path("configs/grafana/dashboards").glob("*.json"):
+              try:
+                  data = json.loads(p.read_text())
+                  assert "panels" in data, f"{p}: missing 'panels'"
+                  assert data.get("uid"), f"{p}: missing 'uid'"
+                  print(f"OK   {p}  ({len(data['panels'])} panels, uid={data['uid']})")
+              except Exception as exc:  # noqa: BLE001
+                  ok = False
+                  print(f"FAIL {p}: {exc}", file=sys.stderr)
+          sys.exit(0 if ok else 1)
+          PY
+
+      - name: Boot the API and run smoke probes
+        run: |
+          uvicorn fraud_detection.serving.app:app --host 127.0.0.1 --port 8000 &
+          SERVER_PID=$!
+          # Wait for the app to come up (lifespan + monitoring init).
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:8000/api/v1/health >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          curl -sSf http://127.0.0.1:8000/api/v1/health | tee /dev/stderr
+          curl -sSf http://127.0.0.1:8000/api/v1/metrics | head -20 || true
+          curl -sSf http://127.0.0.1:8000/api/v1/monitoring/drift | head -5 || true
+          curl -sSf http://127.0.0.1:8000/api/v1/monitoring/performance | head -5 || true
+          curl -sSf http://127.0.0.1:8000/api/v1/monitoring/alerts | head -5 || true
+          curl -sSf http://127.0.0.1:8000/api/v1/monitoring/shadow | head -5 || true
+          kill $SERVER_PID || true

--- a/.github/workflows/promote-model.yml
+++ b/.github/workflows/promote-model.yml
@@ -1,0 +1,136 @@
+name: Promote model
+
+# Manual workflow that promotes a candidate model from MLflow to a
+# deployed alias (default: ``production``). Mirrors the Phase 7 plan's
+# "manual model promotion workflow" requirement.
+#
+# Inputs:
+#   run_id      MLflow run that produced the model artifact.
+#   version     Registry version of the model (printed by `train.py`).
+#   alias       Registry alias to apply (default: production).
+#   tracking_uri  MLflow tracking URI. Defaults to file:./mlflow.db so it
+#                 round-trips locally without a server. In production set
+#                 this to the deployed tracking server.
+#
+# This intentionally runs **only on workflow_dispatch** so a human is
+# always in the loop. The job also writes a Markdown summary to the run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "MLflow run ID of the candidate model"
+        required: true
+        type: string
+      version:
+        description: "Model registry version (e.g. 12)"
+        required: true
+        type: string
+      alias:
+        description: "Registry alias to promote to (production, challenger, ...)"
+        required: false
+        default: "production"
+        type: string
+      tracking_uri:
+        description: "MLflow tracking URI"
+        required: false
+        default: "sqlite:///mlflow.db"
+        type: string
+      model_name:
+        description: "Registered model name"
+        required: false
+        default: "meshwatch-ensemble"
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  promote:
+    name: Promote ${{ inputs.model_name }} v${{ inputs.version }} -> ${{ inputs.alias }}
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package + MLflow
+        run: |
+          python -m pip install --upgrade pip
+          pip install "mlflow>=2.16"
+
+      - name: Inspect candidate run
+        env:
+          MLFLOW_TRACKING_URI: ${{ inputs.tracking_uri }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          import mlflow
+
+          run_id = "${{ inputs.run_id }}"
+          client = mlflow.tracking.MlflowClient()
+          try:
+              run = client.get_run(run_id)
+          except Exception as exc:  # noqa: BLE001
+              print(f"::error::Could not load run {run_id}: {exc}")
+              sys.exit(1)
+
+          metrics = dict(run.data.metrics)
+          params = dict(run.data.params)
+          print("Run status:", run.info.status)
+          print("Metrics:", json.dumps(metrics, indent=2))
+          print("Params:", json.dumps(params, indent=2))
+
+          # Guard-rails: refuse to promote if the candidate's reported test
+          # AUPRC is below the Phase 7 model-degradation threshold.
+          test_auprc = float(metrics.get("test_auprc", metrics.get("auprc", 0.0)))
+          if test_auprc < 0.60:
+              print(
+                  f"::error::Candidate AUPRC {test_auprc:.3f} is below the 0.60 floor; "
+                  "refusing to promote."
+              )
+              sys.exit(2)
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a") as fh:
+                  fh.write(f"# Promotion candidate `{run_id}`\n\n")
+                  fh.write(f"- AUPRC: **{test_auprc:.4f}**\n")
+                  fh.write(f"- Params: `{json.dumps(params)}`\n\n")
+          PY
+
+      - name: Apply registry alias
+        env:
+          MLFLOW_TRACKING_URI: ${{ inputs.tracking_uri }}
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+          import mlflow
+
+          model_name = "${{ inputs.model_name }}"
+          version = "${{ inputs.version }}"
+          alias = "${{ inputs.alias }}"
+
+          client = mlflow.tracking.MlflowClient()
+          try:
+              client.set_registered_model_alias(model_name, alias, version)
+          except Exception as exc:  # noqa: BLE001
+              print(f"::error::Failed to set alias '{alias}' on {model_name} v{version}: {exc}")
+              sys.exit(1)
+          print(f"Set alias '{alias}' on {model_name} v{version}.")
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a") as fh:
+                  fh.write(f"## Promoted\n\n`{model_name}` v{version} -> alias **{alias}**\n")
+          PY

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ TEST_DIR := tests
         investigate investigate-critical investigate-ollama \
         dashboard-install dashboard-dev dashboard-build dashboard-test dashboard-lint dashboard-preview \
         docker-build-dashboard \
+        drift-report drift-report-evidently grafana-open prometheus-open \
         clean clean-data clean-all \
-        tag-phase-1 tag-phase-2 tag-phase-3 tag-phase-4 tag-phase-5 tag-phase-6
+        tag-phase-1 tag-phase-2 tag-phase-3 tag-phase-4 tag-phase-5 tag-phase-6 tag-phase-7
 
 help: ## Show this help
 	@echo "Fraud Detection GNN -- common targets"
@@ -200,6 +201,30 @@ docker-build-dashboard: ## Build the dashboard nginx image locally
 	docker build -t meshwatch/dashboard:dev -f Dockerfile.dashboard .
 
 # ---------------------------------------------------------------------------
+# Monitoring (Phase 7)
+# ---------------------------------------------------------------------------
+drift-report: ## Compute drift between train + test splits (writes data/reports/latest/)
+	$(PY) scripts/monitor.py \
+		--reference data/splits/train.parquet \
+		--current   data/splits/test.parquet \
+		--output-dir data/reports/latest \
+		--top-k 25
+
+drift-report-evidently: ## Same as drift-report but also writes an Evidently HTML
+	$(PY) scripts/monitor.py \
+		--reference data/splits/train.parquet \
+		--current   data/splits/test.parquet \
+		--output-dir data/reports/latest \
+		--with-evidently \
+		--top-k 25
+
+grafana-open: ## Open the local Grafana dashboard (after `make compose-up`)
+	@echo "Grafana: http://localhost:3000  (admin / admin)"
+
+prometheus-open: ## Open the local Prometheus UI (after `make compose-up`)
+	@echo "Prometheus: http://localhost:9090"
+
+# ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
 clean: ## Remove caches and build artifacts
@@ -238,3 +263,7 @@ tag-phase-5: ## Tag v0.5.0-agent-investigator
 tag-phase-6: ## Tag v0.6.0-dashboard
 	git tag -a v0.6.0-dashboard -m "Phase 6: React Dashboard"
 	@echo "Tag created. Push with: git push origin v0.6.0-dashboard"
+
+tag-phase-7: ## Tag v0.7.0-mlops
+	git tag -a v0.7.0-mlops -m "Phase 7: MLOps & Monitoring"
+	@echo "Tag created. Push with: git push origin v0.7.0-mlops"

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@
 > Serve, and auto-investigates alerts with a LangGraph agent. A React
 > dashboard visualises the fraud network. Built on IEEE-CIS (590K transactions).
 
-[![Phase](https://img.shields.io/badge/phase-6%2F8-blue)](./Fraud_Detection_GNN_Implementation_Plan.pdf)
+[![Phase](https://img.shields.io/badge/phase-7%2F8-blue)](./Fraud_Detection_GNN_Implementation_Plan.pdf)
 [![Python](https://img.shields.io/badge/python-3.10%2B-brightgreen)]()
 [![License](https://img.shields.io/badge/license-MIT-lightgrey)]()
-[![Tests](https://img.shields.io/badge/tests-299%20%2B%2032-success)]()
+[![Tests](https://img.shields.io/badge/tests-403%20%2B%2032-success)]()
 [![Latency](https://img.shields.io/badge/predict-P95%201.6ms-success)]()
 [![Agent](https://img.shields.io/badge/investigate-%3C50ms-success)]()
 [![Dashboard](https://img.shields.io/badge/dashboard-Vite%206-blue)]()
+[![Monitoring](https://img.shields.io/badge/monitoring-Prometheus%20%2B%20Grafana-orange)]()
 
 Production-grade fraud detection on the **IEEE-CIS** dataset (590,540 transactions, 3.5% fraud rate)
 combining a **heterogeneous GNN** (PyTorch Geometric) with an **XGBoost ensemble**, served in
@@ -94,6 +95,28 @@ make dashboard-build      # production bundle -> dashboard/dist/
 # OR run dashboard alongside the rest of the stack:
 make compose-up           # api + dashboard + redis + kafka + mlflow + prometheus + grafana
 #                         # dashboard at http://localhost:5173, api at http://localhost:8000
+
+# 10. Phase 7: MLOps + monitoring (drift / performance / Prometheus / Grafana)
+make drift-report         # PSI/KS/chi2/JSD report -> data/reports/latest/drift.{json,html}
+make drift-report-evidently # same + an Evidently HTML report (needs [monitor] extra)
+make compose-up           # boots Prometheus (with alert rules) + Grafana (with the
+#                         # Meshwatch MLOps dashboard auto-provisioned)
+make grafana-open         # http://localhost:3000  (admin / admin)
+make prometheus-open      # http://localhost:9090
+# Endpoints (live on the FastAPI app):
+#   GET  /api/v1/monitoring/drift          -- last drift report (JSON)
+#   GET  /api/v1/monitoring/drift.html     -- the same report rendered as HTML
+#   GET  /api/v1/monitoring/performance    -- rolling precision/recall/F1/AUROC
+#   GET  /api/v1/monitoring/alerts         -- mirror of Prometheus rules (incl. FraudRateSpike, ModelDegradation)
+#   POST /api/v1/monitoring/label          -- attach a chargeback label to a previous txn
+#   GET  /api/v1/monitoring/shadow         -- champion/challenger agreement summary
+#   GET  /api/v1/monitoring/shadow/recent  -- recent shadow decisions
+
+# Grafana auto-provisions 4 dashboards at startup:
+#   * Meshwatch -- Operational         (RPS, latency, error rate, alert volume)
+#   * Meshwatch -- Model Performance   (PSI, precision/recall, AUC, label drift)
+#   * Meshwatch -- Agent Analytics     (LangGraph investigations, tool failures)
+#   * Meshwatch -- Infrastructure      (shadow agreement, in-flight, status codes)
 ```
 
 ---
@@ -105,7 +128,12 @@ Meshwatch/
 ├── .github/workflows/        # CI (lint + tests across Py 3.10 / 3.11 / 3.12)
 ├── configs/
 │   ├── base.yaml             # project-wide settings
-│   └── feast/                # feature store config + feature views
+│   ├── feast/                # feature store config + feature views
+│   ├── prometheus.yml        # Prometheus scrape config (Phase 4)
+│   ├── prometheus_rules.yml  # alert rules (Phase 7)
+│   └── grafana/
+│       ├── provisioning/     # auto-load datasource + dashboard provider
+│       └── dashboards/       # 4 dashboards: operational / model / agent / infra
 ├── data/                     # raw / processed / splits / graphs (gitignored)
 ├── notebooks/
 │   ├── 01_eda.ipynb              # Phase 1 -- raw-data EDA
@@ -123,7 +151,8 @@ Meshwatch/
 │   ├── evaluate.py               # Phase 3: PR/ROC/calibration on val or test
 │   ├── serve.py                  # Phase 4: FastAPI / Ray Serve launcher
 │   ├── demo_stream.py            # Phase 4: replay txns to /api/v1/predict
-│   └── investigate.py            # Phase 5: run the LangGraph investigator on a synthetic alert
+│   ├── investigate.py            # Phase 5: run the LangGraph investigator on a synthetic alert
+│   └── monitor.py                # Phase 7: compute a drift report between two splits
 ├── dashboard/                    # Phase 6: React 18 + TS + Vite frontend
 │   ├── src/{api,components,pages,store,lib}/
 │   ├── tests/                    # 32 Vitest tests
@@ -137,7 +166,7 @@ Meshwatch/
 │   ├── serving/              # FastAPI app, Ray Serve deployment, schemas   (Phase 4)
 │   ├── streaming/            # Kafka producer/consumer                      (Phase 4)
 │   ├── agent/                # LangGraph agent, 8 tools, prompts            (Phase 5)
-│   ├── monitoring/           # Evidently drift, Prometheus metrics          (Phase 7)
+│   ├── monitoring/           # drift + perf + alerts + Prometheus registry (Phase 7)
 │   └── utils/                # config, logging, timing
 ├── tests/{unit,integration,e2e}/
 ├── pyproject.toml
@@ -155,7 +184,7 @@ Python (backend, agent, training):
 make lint            # ruff check
 make format          # ruff format + autofix
 make typecheck       # mypy
-make test            # pytest unit tests (299 tests, ~50 s)
+make test            # pytest unit tests (403 tests, ~50 s)
 make test-cov        # unit tests with coverage report
 ```
 
@@ -167,9 +196,20 @@ make dashboard-test  # vitest run (32 tests)
 make dashboard-build # production Vite bundle -> dashboard/dist/
 ```
 
-CI runs the full Python matrix (Python 3.10 / 3.11 / 3.12) on every push + PR
-via `.github/workflows/ci.yml`. The dashboard test suite is run locally; a
-dedicated CI job lands in Phase 7 alongside the MLOps work.
+CI runs the full Python matrix (Python 3.10 / 3.11 / 3.12) on every push +
+PR via `.github/workflows/ci.yml`. Phase 7 added two more jobs:
+
+* `dashboard` -- the dashboard's TypeScript type-check, Vitest suite, and
+  production build on Node 20 / 22.
+* `integration` -- validates `configs/prometheus_rules.yml` with
+  `promtool check rules`, parses every Grafana dashboard JSON, and runs a
+  smoke probe against the live API (`/health`, `/metrics`,
+  `/monitoring/{drift,performance,alerts,shadow}`).
+
+A separate manual workflow at `.github/workflows/promote-model.yml`
+promotes a candidate model from MLflow to the `production` alias. It
+refuses to promote if the candidate run's `test_auprc` is below `0.60`
+(the Phase 7 `ModelDegradation` floor).
 
 ---
 
@@ -183,8 +223,8 @@ dedicated CI job lands in Phase 7 alongside the MLOps work.
 | 4. Real-Time Serving | `v0.4.0-serving-pipeline` | ✅ Complete |
 | 5. Agentic Investigator | `v0.5.0-agent-investigator` | ✅ Complete |
 | 6. React Dashboard | `v0.6.0-dashboard` | ✅ Complete |
-| 7. MLOps & Monitoring | `v0.7.0-mlops` | 🚧 Up next |
-| 8. Docs, Demo & Polish | `v1.0.0-release` | ⏳ Planned |
+| 7. MLOps & Monitoring | `v0.7.0-mlops` | ✅ Complete |
+| 8. Docs, Demo & Polish | `v1.0.0-release` | 🚧 Up next |
 
 ## License
 

--- a/configs/grafana/dashboards/01_operational.json
+++ b/configs/grafana/dashboards/01_operational.json
@@ -1,0 +1,236 @@
+{
+  "annotations": { "list": [] },
+  "description": "Meshwatch -- Operational (RPS, latency, error rate, alert volume)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Predictions / second",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(meshwatch_predictions_total[1m]))",
+          "legendFormat": "rps",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "id": 1
+    },
+    {
+      "type": "stat",
+      "title": "P95 inference latency",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(meshwatch_http_request_latency_seconds_bucket{path=~\"/api/v1/predict.*\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.025 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "id": 2
+    },
+    {
+      "type": "stat",
+      "title": "5xx error rate (5m)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(meshwatch_http_requests_total{status=~\"5..\"}[5m])) / clamp_min(sum(rate(meshwatch_http_requests_total[5m])), 0.001)",
+          "legendFormat": "5xx rate",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+      "id": 3
+    },
+    {
+      "type": "stat",
+      "title": "Alerts published / min",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(meshwatch_alerts_published_total[5m])) * 60",
+          "legendFormat": "alerts/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 20 },
+              { "color": "red", "value": 100 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "id": 4
+    },
+    {
+      "type": "timeseries",
+      "title": "Predictions by risk level",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (risk_level) (rate(meshwatch_predictions_total[1m]))",
+          "legendFormat": "{{risk_level}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 5
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP latency P50 / P95 / P99",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(meshwatch_http_request_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(meshwatch_http_request_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(meshwatch_http_request_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 5 }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 6
+    },
+    {
+      "type": "timeseries",
+      "title": "Production fraud rate vs. reference",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "meshwatch_production_fraud_rate", "legendFormat": "production", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 0.2,
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 5 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.05 },
+              { "color": "red", "value": 0.10 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "id": 7
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["meshwatch", "phase-7", "operational"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Meshwatch -- Operational",
+  "uid": "meshwatch-operational",
+  "version": 1,
+  "weekStart": ""
+}

--- a/configs/grafana/dashboards/02_model_performance.json
+++ b/configs/grafana/dashboards/02_model_performance.json
@@ -1,0 +1,230 @@
+{
+  "annotations": { "list": [] },
+  "description": "Meshwatch -- Model Performance (precision/recall/AUC + drift)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "gauge",
+      "title": "Overall PSI",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "meshwatch_drift_psi_overall", "legendFormat": "psi", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 0.5,
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.1 },
+              { "color": "red", "value": 0.25 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 0 },
+      "id": 1
+    },
+    {
+      "type": "stat",
+      "title": "Severe drift features",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "meshwatch_drift_features_severe", "legendFormat": "severe", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2
+    },
+    {
+      "type": "stat",
+      "title": "Moderate drift features",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "meshwatch_drift_features_moderate", "legendFormat": "moderate", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 4 },
+      "id": 3
+    },
+    {
+      "type": "bargauge",
+      "title": "Top features by PSI",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "topk(10, meshwatch_drift_psi_feature)",
+          "legendFormat": "{{feature}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.1 },
+              { "color": "red", "value": 0.25 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "orientation": "horizontal", "displayMode": "gradient" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 4
+    },
+    {
+      "type": "timeseries",
+      "title": "Precision / Recall / F1",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "meshwatch_performance_precision", "legendFormat": "precision", "refId": "A" },
+        { "expr": "meshwatch_performance_recall", "legendFormat": "recall", "refId": "B" },
+        { "expr": "meshwatch_performance_f1", "legendFormat": "f1", "refId": "C" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "max": 1,
+          "custom": { "drawStyle": "line", "lineWidth": 2 }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 5
+    },
+    {
+      "type": "timeseries",
+      "title": "AUROC / AUPRC",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "meshwatch_performance_auroc", "legendFormat": "auroc", "refId": "A" },
+        { "expr": "meshwatch_performance_auprc", "legendFormat": "auprc", "refId": "B" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "max": 1,
+          "custom": { "drawStyle": "line", "lineWidth": 2 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.60 },
+              { "color": "green", "value": 0.85 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 6
+    },
+    {
+      "type": "timeseries",
+      "title": "Label drift (|production - reference|)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "meshwatch_label_drift", "legendFormat": "label drift", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineWidth": 2 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.025 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 7
+    },
+    {
+      "type": "timeseries",
+      "title": "Prediction distribution drift (PSI)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "meshwatch_prediction_distribution_drift",
+          "legendFormat": "score psi",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineWidth": 2 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.1 },
+              { "color": "red", "value": 0.25 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 8
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["meshwatch", "phase-7", "model"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Meshwatch -- Model Performance",
+  "uid": "meshwatch-model",
+  "version": 1,
+  "weekStart": ""
+}

--- a/configs/grafana/dashboards/03_agent_analytics.json
+++ b/configs/grafana/dashboards/03_agent_analytics.json
@@ -1,0 +1,220 @@
+{
+  "annotations": { "list": [] },
+  "description": "Meshwatch -- Agent Analytics (LangGraph investigator)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Investigations / min",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(meshwatch_agent_invocations_total[5m])) * 60",
+          "legendFormat": "rpm",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "id": 1
+    },
+    {
+      "type": "stat",
+      "title": "Failure rate (10m)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(meshwatch_agent_invocations_total{status=\"error\"}[10m])) / clamp_min(sum(rate(meshwatch_agent_invocations_total[10m])), 0.001)",
+          "legendFormat": "fail rate",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.05 },
+              { "color": "red", "value": 0.10 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "id": 2
+    },
+    {
+      "type": "stat",
+      "title": "P95 run latency",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(meshwatch_agent_run_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 10 },
+              { "color": "red", "value": 30 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+      "id": 3
+    },
+    {
+      "type": "timeseries",
+      "title": "Invocations by risk level",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (risk_level) (rate(meshwatch_agent_invocations_total[5m])) * 60",
+          "legendFormat": "{{risk_level}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 4
+    },
+    {
+      "type": "timeseries",
+      "title": "P95 latency by risk level",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(meshwatch_agent_run_latency_seconds_bucket[5m])) by (le, risk_level))",
+          "legendFormat": "{{risk_level}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "lineWidth": 2 }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 5
+    },
+    {
+      "type": "bargauge",
+      "title": "Tool invocations (top 10, by rate)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (tool) (rate(meshwatch_agent_tool_invocations_total[5m])))",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "orientation": "horizontal", "displayMode": "gradient" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "id": 6
+    },
+    {
+      "type": "bargauge",
+      "title": "Tool failures (top 10, by rate)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (tool) (rate(meshwatch_agent_tool_invocations_total{status=\"error\"}[10m])))",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.01 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "orientation": "horizontal", "displayMode": "gradient" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "id": 7
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["meshwatch", "phase-7", "agent"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Meshwatch -- Agent Analytics",
+  "uid": "meshwatch-agent",
+  "version": 1,
+  "weekStart": ""
+}

--- a/configs/grafana/dashboards/04_infrastructure.json
+++ b/configs/grafana/dashboards/04_infrastructure.json
@@ -1,0 +1,202 @@
+{
+  "annotations": { "list": [] },
+  "description": "Meshwatch -- Infrastructure (API + shadow lane + WebSocket)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "In-flight requests",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "meshwatch_http_in_flight_requests", "legendFormat": "in flight", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "id": 1
+    },
+    {
+      "type": "stat",
+      "title": "WebSocket alerts (5m rate * 60)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(meshwatch_alerts_published_total{channel=\"websocket\"}[5m])) * 60",
+          "legendFormat": "ws/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 2 },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "id": 2
+    },
+    {
+      "type": "stat",
+      "title": "Shadow agreement rate",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "meshwatch_shadow_agreement_rate",
+          "legendFormat": "agreement",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.90 },
+              { "color": "green", "value": 0.95 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+      "id": 3
+    },
+    {
+      "type": "stat",
+      "title": "Shadow challenger P95",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(meshwatch_shadow_challenger_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.05 },
+              { "color": "red", "value": 0.1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "id": 4
+    },
+    {
+      "type": "timeseries",
+      "title": "Requests by status code",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(meshwatch_http_requests_total[1m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "bars", "fillOpacity": 60 }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 5
+    },
+    {
+      "type": "timeseries",
+      "title": "Shadow decisions (agree vs. disagree)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(meshwatch_shadow_decisions_total[5m]))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 6
+    },
+    {
+      "type": "heatmap",
+      "title": "Shadow |score delta| heatmap",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(meshwatch_shadow_score_delta_bucket[5m])) by (le)",
+          "legendFormat": "{{le}}",
+          "refId": "A",
+          "format": "heatmap"
+        }
+      ],
+      "fieldConfig": { "defaults": { "custom": {} }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "id": 7
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["meshwatch", "phase-7", "infrastructure"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Meshwatch -- Infrastructure",
+  "uid": "meshwatch-infra",
+  "version": 1,
+  "weekStart": ""
+}

--- a/configs/grafana/provisioning/dashboards/dashboards.yml
+++ b/configs/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,20 @@
+# Grafana dashboard provisioning (Phase 7).
+#
+# Tells Grafana to load every JSON dashboard from /var/lib/grafana/dashboards
+# (mounted from configs/grafana/dashboards/ in docker-compose.yml) at
+# startup. ``allowUiUpdates`` is on so operators can iterate, but
+# foldersFromFilesStructure keeps the file/folder hierarchy in source.
+
+apiVersion: 1
+
+providers:
+  - name: meshwatch
+    orgId: 1
+    folder: Meshwatch
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/configs/grafana/provisioning/datasources/datasource.yml
+++ b/configs/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,18 @@
+# Grafana datasource provisioning (Phase 7).
+#
+# Auto-provisions a single Prometheus datasource that points at the
+# containerised prometheus service from docker-compose.yml. Loaded by
+# Grafana at startup; no clicking required.
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 15s
+      httpMethod: POST

--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -1,8 +1,8 @@
-# Prometheus scrape config for the Meshwatch infrastructure (Phase 4).
+# Prometheus scrape config for the Meshwatch infrastructure (Phases 4 + 7).
 #
 # Scrapes the FastAPI app's /api/v1/metrics endpoint and Prometheus's own
-# self-metrics. Phase 7 adds drift / model-degradation alert rules in
-# configs/prometheus_rules.yml.
+# self-metrics. Phase 7 added the alert rules referenced via ``rule_files``;
+# the matching Grafana dashboard lives in ``configs/grafana/dashboards``.
 
 global:
   scrape_interval: 15s
@@ -10,6 +10,9 @@ global:
   external_labels:
     service: meshwatch
     env: local
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
 
 scrape_configs:
   - job_name: prometheus

--- a/configs/prometheus_rules.yml
+++ b/configs/prometheus_rules.yml
@@ -1,0 +1,235 @@
+# Meshwatch Prometheus alert rules (Phase 7).
+#
+# These mirror the application-side rules in
+# src/fraud_detection/monitoring/alerts.py so dashboards (Grafana) and
+# the application's /api/v1/monitoring/alerts endpoint stay aligned.
+#
+# Severity convention:
+#   * critical  -- pages oncall, requires human action
+#   * warning   -- informational; auto-resolves when condition clears
+#
+# Threshold sources (see Fraud_Detection_GNN_Implementation_Plan.pdf, p. 11):
+#   * HighLatency:    P95 > 50ms (the Phase 4 latency budget)
+#   * FraudRateSpike: production fraud rate > 10%
+#   * DataDrift:      > 10 features with PSI >= alert threshold
+#   * ModelDegradation: production AUPRC < 0.60 (was 0.70 at training)
+#
+# All rules use the meshwatch_* metric namespace exposed by the API at
+# /api/v1/metrics. The scrape config lives in configs/prometheus.yml.
+
+groups:
+  - name: meshwatch.serving
+    interval: 30s
+    rules:
+      - alert: ModelNotLoaded
+        expr: absent(meshwatch_http_requests_total{path="/api/v1/predict"}) == 1
+        for: 2m
+        labels:
+          severity: critical
+          team: ml-platform
+        annotations:
+          summary: "Meshwatch model is not serving predictions"
+          description: |
+            No requests have been scraped for /api/v1/predict in the last 2 minutes.
+            The FraudPredictor may have failed to load at startup; check
+            the api container logs for "predictor_load_failed".
+
+      - alert: HighErrorRate
+        expr: |
+          (
+            sum(rate(meshwatch_http_requests_total{status=~"5.."}[5m]))
+            /
+            sum(rate(meshwatch_http_requests_total[5m]))
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+          team: ml-platform
+        annotations:
+          summary: "5xx error rate > 5% on /api/v1"
+          description: |
+            HTTP 5xx rate has been above 5% for the last 5 minutes.
+            Inspect ``meshwatch_http_requests_total`` by path/status and
+            the predictor logs.
+
+      - alert: HighLatency
+        # Plan budget: P95 < 50ms on /api/v1/predict (see Phase 4, page 9).
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(meshwatch_http_request_latency_seconds_bucket{path=~"/api/v1/predict.*"}[5m])) by (le)
+          ) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+          team: ml-platform
+        annotations:
+          summary: "P95 inference latency exceeded the 50ms budget"
+          description: |
+            P95 latency on /api/v1/predict has been above the 50ms budget
+            for 10 minutes. The Phase 4 latency budget is 50ms.
+
+  - name: meshwatch.fraud_signal
+    interval: 1m
+    rules:
+      - alert: FraudRateSpike
+        # Plan threshold: alert when the production fraud rate climbs past 10%.
+        # Training-time rate is 3.5%; sustained > 10% is either a real attack
+        # or a model-side bug worth paging on.
+        expr: meshwatch_production_fraud_rate > 0.10
+        for: 5m
+        labels:
+          severity: critical
+          team: ml-platform
+        annotations:
+          summary: "Production fraud rate spike (> 10%)"
+          description: |
+            ``meshwatch_production_fraud_rate`` has stayed above 10% for
+            5 minutes (training baseline = 3.5%). Either there is an
+            ongoing attack, or the model's calibration has drifted.
+
+      - alert: LabelDriftHigh
+        expr: meshwatch_label_drift > 0.05
+        for: 30m
+        labels:
+          severity: warning
+          team: ml-platform
+        annotations:
+          summary: "Label drift > 5 percentage points"
+          description: |
+            |production - reference| fraud rate > 0.05. Combined with a
+            data-drift signal, this often indicates retraining is overdue.
+
+  - name: meshwatch.drift
+    interval: 1m
+    rules:
+      - alert: DataDriftSevere
+        expr: meshwatch_drift_psi_overall >= 0.25
+        for: 10m
+        labels:
+          severity: critical
+          team: ml-platform
+        annotations:
+          summary: "Severe data drift detected (overall PSI {{ $value | printf \"%.3f\" }})"
+          description: |
+            Overall PSI between training and production has been >= 0.25
+            for 10 minutes. Inspect ``meshwatch_drift_psi_feature`` for
+            the worst offenders, and consider re-training the ensemble.
+
+      - alert: DataDriftModerate
+        expr: meshwatch_drift_psi_overall >= 0.10 and meshwatch_drift_psi_overall < 0.25
+        for: 30m
+        labels:
+          severity: warning
+          team: ml-platform
+        annotations:
+          summary: "Moderate data drift (overall PSI {{ $value | printf \"%.3f\" }})"
+          description: |
+            Overall PSI is in the [0.10, 0.25) band. Worth investigating
+            but not yet pageable.
+
+      - alert: DataDrift
+        # Plan threshold: > 10 features with severe drift.
+        expr: meshwatch_drift_features_severe > 10
+        for: 30m
+        labels:
+          severity: warning
+          team: ml-platform
+        annotations:
+          summary: "More than 10 features show severe drift"
+          description: |
+            ``meshwatch_drift_features_severe`` has been > 10 for 30 minutes.
+            Even if the overall PSI is low this suggests a coordinated
+            distribution shift across multiple feature families.
+
+      - alert: PredictionDistributionDrift
+        expr: meshwatch_prediction_distribution_drift >= 0.25
+        for: 30m
+        labels:
+          severity: warning
+          team: ml-platform
+        annotations:
+          summary: "Score distribution drifted vs. reference"
+          description: |
+            PSI between production score distribution and the reference
+            baseline is at or above 0.25. The model is making predictions
+            with a different shape than at calibration time.
+
+  - name: meshwatch.performance
+    interval: 5m
+    rules:
+      - alert: ModelDegradation
+        # Plan threshold: production AUPRC < 0.60 (training baseline 0.70).
+        expr: meshwatch_performance_auprc < 0.60 and meshwatch_performance_n_labelled > 50
+        for: 1h
+        labels:
+          severity: critical
+          team: ml-platform
+        annotations:
+          summary: "Production AUPRC below 0.60"
+          description: |
+            AUPRC on labelled production transactions has been below 0.60
+            for an hour. The Phase 3 ensemble baseline is 0.70 -- this is
+            a clear degradation signal.
+
+      - alert: ModelPerformanceDegraded
+        expr: meshwatch_performance_recall < 0.55 and meshwatch_performance_n_labelled > 50
+        for: 30m
+        labels:
+          severity: warning
+          team: ml-platform
+        annotations:
+          summary: "Production recall < 0.55"
+          description: |
+            Recall on labelled production transactions has stayed below
+            0.55 for 30 minutes.
+
+      - alert: ProductionAUROCDrop
+        expr: meshwatch_performance_auroc < 0.85 and meshwatch_performance_n_labelled > 50
+        for: 1h
+        labels:
+          severity: warning
+          team: ml-platform
+        annotations:
+          summary: "Production AUROC below 0.85"
+          description: |
+            AUROC on labelled production transactions has been below 0.85
+            for an hour. The Phase 3 test-set AUROC was 0.92.
+
+  - name: meshwatch.agent
+    interval: 1m
+    rules:
+      - alert: AgentInvestigationsFailing
+        expr: |
+          (
+            sum(rate(meshwatch_agent_invocations_total{status="error"}[10m]))
+            /
+            clamp_min(sum(rate(meshwatch_agent_invocations_total[10m])), 0.001)
+          ) > 0.10
+        for: 10m
+        labels:
+          severity: warning
+          team: ml-platform
+        annotations:
+          summary: "Agent investigation failure rate > 10%"
+          description: |
+            More than 10% of agent investigations are erroring out.
+            Check ``meshwatch_agent_tool_invocations_total{status="error"}``
+            to identify the failing tool.
+
+  - name: meshwatch.shadow
+    interval: 1m
+    rules:
+      - alert: ShadowChallengerDisagreement
+        expr: meshwatch_shadow_agreement_rate < 0.90
+        for: 30m
+        labels:
+          severity: warning
+          team: ml-platform
+        annotations:
+          summary: "Champion / challenger agreement rate < 90%"
+          description: |
+            The shadow challenger disagrees with the champion on more
+            than 10% of recent transactions. Inspect
+            ``/api/v1/monitoring/shadow/recent`` for examples before
+            promoting the challenger.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       - "9090:9090"
     volumes:
       - ./configs/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./configs/prometheus_rules.yml:/etc/prometheus/rules/prometheus_rules.yml:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
@@ -104,6 +105,11 @@ services:
       GF_USERS_ALLOW_SIGN_UP: "false"
     volumes:
       - grafana_data:/var/lib/grafana
+      # Phase 7 -- auto-provision the Prometheus datasource + the
+      # Meshwatch MLOps dashboard so a clean `docker compose up` lands
+      # operators directly on the live dashboard with no clicking.
+      - ./configs/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./configs/grafana/dashboards:/var/lib/grafana/dashboards:ro
 
   api:
     build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fraud-detection-gnn"
-version = "0.1.0"
+version = "0.7.0"
 description = "Real-time transaction fraud detection using heterogeneous GNNs + agentic LLM investigation."
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -1,0 +1,255 @@
+"""CLI: compute a drift report between a reference (training) split and
+a current (recent production) split.
+
+Examples
+--------
+
+# Default paths: data/splits/train.parquet vs data/splits/test.parquet
+python scripts/monitor.py
+
+# Use an explicit current window (e.g. recent production capture)
+python scripts/monitor.py \
+    --reference data/splits/train.parquet \
+    --current   data/captures/2026-05-01.parquet \
+    --output-dir data/reports/2026-05-01 \
+    --top-k 25
+
+# Restrict the comparison to a feature subset
+python scripts/monitor.py --features TransactionAmt,card1,P_emaildomain
+
+Writes both a JSON and an HTML report under ``--output-dir`` and -- when
+MLflow is available -- mirrors the summary metrics under the
+``meshwatch-production`` experiment.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+import click
+
+from fraud_detection.monitoring import (
+    DriftDetector,
+    DriftDetectorConfig,
+    DriftReport,
+    evidently_html_report,
+    label_drift,
+    monitoring_metrics,
+    prediction_distribution_drift,
+    write_html,
+    write_json,
+)
+from fraud_detection.utils.logging import configure_logging, get_logger
+
+log = get_logger(__name__)
+
+
+def _load_frame(path: Path) -> dict[str, list]:
+    """Load a Parquet / CSV file into ``dict[col, list[value]]``."""
+    import pandas as pd
+
+    suffix = path.suffix.lower()
+    if suffix in {".parquet", ".pq"}:
+        df = pd.read_parquet(path)
+    elif suffix in {".csv", ".tsv", ".txt"}:
+        sep = "\t" if suffix == ".tsv" else ","
+        df = pd.read_csv(path, sep=sep)
+    else:
+        raise click.BadParameter(f"Unsupported file format: {path.suffix}")
+    return {col: df[col].tolist() for col in df.columns}
+
+
+def _filter_features(
+    frame: dict[str, list],
+    features: Iterable[str] | None,
+) -> dict[str, list]:
+    if not features:
+        return frame
+    keep = set(features)
+    return {k: v for k, v in frame.items() if k in keep}
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "--reference",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=Path("data/splits/train.parquet"),
+    show_default=True,
+    help="Reference distribution (typically the training split).",
+)
+@click.option(
+    "--current",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=Path("data/splits/test.parquet"),
+    show_default=True,
+    help="Current distribution (typically a recent production capture).",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path("data/reports/latest"),
+    show_default=True,
+    help="Where to write drift.json + drift.html.",
+)
+@click.option(
+    "--features",
+    type=str,
+    default=None,
+    help="Comma-separated subset of features to compare (default: all overlapping cols).",
+)
+@click.option(
+    "--top-k",
+    type=int,
+    default=20,
+    show_default=True,
+    help="Print this many top-drifted features to stdout.",
+)
+@click.option(
+    "--psi-warn", type=float, default=0.10, show_default=True, help="Warn threshold for PSI."
+)
+@click.option(
+    "--psi-alert", type=float, default=0.25, show_default=True, help="Alert threshold for PSI."
+)
+@click.option(
+    "--with-evidently/--no-evidently",
+    default=False,
+    show_default=True,
+    help="Also write an Evidently HTML report (requires the [monitor] extra).",
+)
+@click.option(
+    "--mlflow/--no-mlflow",
+    default=False,
+    show_default=True,
+    help="Log summary metrics to MLflow under experiment 'meshwatch-production'.",
+)
+def main(
+    reference: Path,
+    current: Path,
+    output_dir: Path,
+    features: str | None,
+    top_k: int,
+    psi_warn: float,
+    psi_alert: float,
+    with_evidently: bool,
+    mlflow: bool,
+) -> None:
+    """Compute drift between two snapshots and write a JSON + HTML report."""
+    configure_logging(level="INFO")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    log.info("monitor_loading_reference", path=str(reference))
+    ref_frame = _load_frame(reference)
+    log.info("monitor_loading_current", path=str(current))
+    cur_frame = _load_frame(current)
+
+    feature_list = (
+        [f.strip() for f in features.split(",") if f.strip()] if features is not None else None
+    )
+    ref_frame = _filter_features(ref_frame, feature_list)
+    cur_frame = _filter_features(cur_frame, feature_list)
+
+    common = sorted(set(ref_frame) & set(cur_frame))
+    if not common:
+        click.echo("No overlapping features between reference and current.", err=True)
+        sys.exit(2)
+    ref_frame = {k: ref_frame[k] for k in common}
+    cur_frame = {k: cur_frame[k] for k in common}
+
+    detector = DriftDetector(
+        ref_frame,
+        config=DriftDetectorConfig(psi_warn=psi_warn, psi_alert=psi_alert),
+    )
+    report: DriftReport = detector.detect(cur_frame)
+
+    json_path = write_json(report, output_dir / "drift.json")
+    html_path = write_html(report, output_dir / "drift.html")
+    log.info(
+        "monitor_report_written",
+        json=str(json_path),
+        html=str(html_path),
+        overall_psi=report.overall_psi,
+        severity=report.severity,
+        n_features=report.n_features,
+        n_severe=report.n_severe,
+    )
+
+    # Print the top-k offenders to stdout so this script doubles as a
+    # human-readable diagnostic without anyone opening the HTML.
+    click.echo("")
+    click.echo(f"Overall PSI: {report.overall_psi:.4f}  ({report.severity})")
+    click.echo(f"Features evaluated: {report.n_features}  |  severe: {report.n_severe}")
+    click.echo("")
+    click.echo(f"{'Feature':<32} {'Kind':<12} {'PSI':>8} {'Severity':<10}")
+    click.echo("-" * 64)
+    for f in report.top(top_k):
+        click.echo(f"{f.feature[:31]:<32} {f.kind:<12} {f.psi:>8.4f} {f.severity:<10}")
+    click.echo("")
+
+    # Optional Evidently HTML (richer, but bigger and slower).
+    if with_evidently:
+        ev_path = output_dir / "drift_evidently.html"
+        result = evidently_html_report(ref_frame, cur_frame, output_path=str(ev_path))
+        if result is None:
+            log.warning(
+                "monitor_evidently_skipped",
+                reason="evidently not installed (install with `pip install -e .[monitor]`)",
+            )
+        else:
+            log.info("monitor_evidently_written", path=str(ev_path))
+
+    # Update Prometheus gauges so any running scraper sees the latest values.
+    monitoring_metrics.update_drift(report)
+
+    # Label drift -- if both sides have ``isFraud`` (the IEEE-CIS target), we
+    # can also surface absolute label drift onto the registry.
+    if "isFraud" in ref_frame and "isFraud" in cur_frame:
+        ref_labels = [v for v in ref_frame["isFraud"] if v is not None]
+        ref_rate = (
+            (sum(int(bool(int(v))) for v in ref_labels) / len(ref_labels)) if ref_labels else 0.035
+        )
+        ld = label_drift(cur_frame["isFraud"], reference_rate=ref_rate)
+        monitoring_metrics.update_label_drift(
+            production_rate=ld["production_rate"],
+            reference_rate=ld["reference_rate"],
+        )
+        click.echo(
+            f"Label drift: production fraud rate {ld['production_rate']:.4f}, "
+            f"reference {ld['reference_rate']:.4f}, "
+            f"|delta| {ld['absolute_drift']:.4f}"
+        )
+
+    # Prediction-distribution drift -- when both sides expose a ``fraud_score``
+    # column (i.e. you exported the predictor's responses), measure PSI on the
+    # score distribution.
+    if "fraud_score" in ref_frame and "fraud_score" in cur_frame:
+        psi = prediction_distribution_drift(
+            production_scores=cur_frame["fraud_score"],
+            reference_scores=ref_frame["fraud_score"],
+        )
+        monitoring_metrics.update_prediction_distribution_drift(psi)
+        click.echo(f"Prediction-distribution PSI: {psi:.4f}")
+
+    # Optional MLflow logging.
+    if mlflow:
+        try:
+            import mlflow as mlf
+
+            mlf.set_experiment("meshwatch-production")
+            with mlf.start_run(run_name="drift-snapshot"):
+                mlf.log_param("reference", str(reference))
+                mlf.log_param("current", str(current))
+                mlf.log_param("n_features", report.n_features)
+                mlf.log_metric("overall_psi", report.overall_psi)
+                mlf.log_metric("n_severe_features", report.n_severe)
+                mlf.log_metric("n_moderate_features", report.n_moderate)
+                mlf.log_artifact(str(json_path))
+                mlf.log_artifact(str(html_path))
+            log.info("monitor_mlflow_logged", experiment="meshwatch-production")
+        except Exception as exc:
+            log.warning("monitor_mlflow_unavailable", error=str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fraud_detection/monitoring/__init__.py
+++ b/src/fraud_detection/monitoring/__init__.py
@@ -1,1 +1,98 @@
-"""Drift detection, metrics, alerting (Phase 7)."""
+"""Drift detection, performance tracking, alerting (Phase 7).
+
+Public API:
+
+* :class:`DriftDetector`, :class:`DriftReport`, :class:`FeatureDrift` --
+  numeric / categorical drift detection with PSI, KS, chi-square and JSD.
+* :class:`PerformanceTracker`, :class:`PerformanceSnapshot` -- rolling
+  classification metrics keyed by labelled arrivals.
+* :class:`MonitoringMetrics`, :data:`monitoring_metrics` -- Prometheus
+  collectors for drift, performance, and the agent layer.
+* :class:`AlertEvaluator`, :class:`AlertRule`, :func:`default_rules` --
+  application-side mirror of the Prometheus alert rules.
+* :func:`report_to_json`, :func:`report_to_html` -- drift report
+  serialisation.
+* :class:`MonitoringState`, :func:`get_state` -- the in-process state
+  holder that the FastAPI app, the CLI and the tests all share.
+"""
+
+from __future__ import annotations
+
+from fraud_detection.monitoring.alerts import (
+    Alert,
+    AlertEvaluator,
+    AlertRule,
+    AlertSeverity,
+    default_rules,
+)
+from fraud_detection.monitoring.drift import (
+    DriftDetector,
+    DriftDetectorConfig,
+    DriftReport,
+    DriftSeverity,
+    FeatureDrift,
+    categorical_psi,
+    chi_square,
+    evidently_html_report,
+    js_divergence,
+    ks_test,
+    label_drift,
+    population_stability_index,
+    prediction_distribution_drift,
+)
+from fraud_detection.monitoring.performance import (
+    PerformanceSnapshot,
+    PerformanceTracker,
+    auprc,
+    auroc,
+)
+from fraud_detection.monitoring.registry import MonitoringMetrics, monitoring_metrics
+from fraud_detection.monitoring.reports import (
+    report_to_html,
+    report_to_json,
+    write_html,
+    write_json,
+)
+from fraud_detection.monitoring.shadow import (
+    ShadowDecision,
+    ShadowDeployment,
+    ShadowSummary,
+)
+from fraud_detection.monitoring.state import MonitoringState, get_state, reset_state
+
+__all__ = [
+    "Alert",
+    "AlertEvaluator",
+    "AlertRule",
+    "AlertSeverity",
+    "DriftDetector",
+    "DriftDetectorConfig",
+    "DriftReport",
+    "DriftSeverity",
+    "FeatureDrift",
+    "MonitoringMetrics",
+    "MonitoringState",
+    "PerformanceSnapshot",
+    "PerformanceTracker",
+    "ShadowDecision",
+    "ShadowDeployment",
+    "ShadowSummary",
+    "auprc",
+    "auroc",
+    "categorical_psi",
+    "chi_square",
+    "default_rules",
+    "evidently_html_report",
+    "get_state",
+    "js_divergence",
+    "ks_test",
+    "label_drift",
+    "monitoring_metrics",
+    "population_stability_index",
+    "prediction_distribution_drift",
+    "report_to_html",
+    "report_to_json",
+    "reset_state",
+    "write_html",
+    "write_json",
+]

--- a/src/fraud_detection/monitoring/alerts.py
+++ b/src/fraud_detection/monitoring/alerts.py
@@ -1,0 +1,285 @@
+"""Alert-rule evaluation (Phase 7).
+
+This module gives the *application* a way to evaluate the same conditions
+that Prometheus is alerting on -- handy for surfacing them in the React
+dashboard or pushing them through the Kafka alert topic without waiting
+for Prometheus to fire.
+
+Two layers:
+
+* :class:`AlertRule` -- a tiny declarative spec (name, severity, predicate,
+  reason builder) you can stack into an :class:`AlertEvaluator`.
+* :func:`default_rules` -- the canonical set of rules that mirrors
+  ``configs/prometheus_rules.yml`` so application-fired alerts and
+  Prometheus-fired alerts stay aligned.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+AlertSeverity = Literal["info", "warning", "critical"]
+
+
+@dataclass(slots=True)
+class AlertRule:
+    """A single declarative rule.
+
+    The ``predicate`` is a pure function over a context dictionary. The
+    context typically holds:
+
+    * ``drift_overall``    -- ``float`` overall PSI
+    * ``drift_severe``     -- ``int`` count of severe-drift features
+    * ``performance``      -- a :class:`PerformanceSnapshot`
+    * ``latency_p95``      -- ``float`` recent P95 in seconds
+    * ``error_rate``       -- ``float`` 0..1 over the last window
+    * ``model_loaded``     -- ``bool``
+
+    ``reason`` is a builder so messages embed live values from the context.
+    """
+
+    name: str
+    severity: AlertSeverity
+    description: str
+    predicate: Callable[[dict[str, Any]], bool]
+    reason: Callable[[dict[str, Any]], str] = field(default=lambda _ctx: "Triggered")
+
+
+@dataclass(slots=True)
+class Alert:
+    """An active alert at a point in time."""
+
+    name: str
+    severity: AlertSeverity
+    description: str
+    reason: str
+    fired_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        if isinstance(d["fired_at"], datetime):
+            d["fired_at"] = d["fired_at"].isoformat()
+        return d
+
+
+class AlertEvaluator:
+    """Evaluate a list of :class:`AlertRule` against a context."""
+
+    def __init__(self, rules: Iterable[AlertRule]) -> None:
+        self.rules: list[AlertRule] = list(rules)
+
+    def evaluate(self, ctx: dict[str, Any]) -> list[Alert]:
+        out: list[Alert] = []
+        for rule in self.rules:
+            try:
+                if rule.predicate(ctx):
+                    out.append(
+                        Alert(
+                            name=rule.name,
+                            severity=rule.severity,
+                            description=rule.description,
+                            reason=rule.reason(ctx),
+                        )
+                    )
+            except Exception as exc:  # pragma: no cover -- defensive only
+                out.append(
+                    Alert(
+                        name=rule.name,
+                        severity="warning",
+                        description=rule.description,
+                        reason=f"Rule evaluation failed: {exc!s}",
+                    )
+                )
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Canonical rule set -- mirrors configs/prometheus_rules.yml
+# ---------------------------------------------------------------------------
+
+
+def _get(ctx: dict[str, Any], key: str, default: Any) -> Any:
+    val = ctx.get(key, default)
+    return default if val is None else val
+
+
+def default_rules(
+    *,
+    psi_alert: float = 0.25,
+    psi_severe_features: int = 10,
+    latency_p95_warn: float = 0.05,  # 50ms -- plan budget
+    error_rate_warn: float = 0.05,
+    performance_recall_warn: float = 0.55,
+    performance_auprc_warn: float = 0.60,
+    fraud_rate_spike: float = 0.10,  # 10% production fraud rate
+    shadow_agreement_warn: float = 0.90,
+) -> list[AlertRule]:
+    """Return the canonical set of rules.
+
+    Defaults mirror ``configs/prometheus_rules.yml`` so that the application
+    surface (``/api/v1/monitoring/alerts``) reports the same conditions as
+    the Prometheus alertmanager. Override any threshold via kwargs if site
+    policy differs.
+    """
+    return [
+        AlertRule(
+            name="ModelNotLoaded",
+            severity="critical",
+            description="The serving process is up but the ensemble artifact failed to load.",
+            predicate=lambda ctx: not bool(ctx.get("model_loaded", True)),
+            reason=lambda _ctx: (
+                "FraudPredictor returned None at startup; /api/v1/predict will 503."
+            ),
+        ),
+        AlertRule(
+            name="DataDriftSevere",
+            severity="critical",
+            description=f"Overall PSI breached the alert threshold ({psi_alert}).",
+            predicate=lambda ctx: float(_get(ctx, "drift_overall", 0.0)) >= psi_alert,
+            reason=lambda ctx: (
+                f"Overall PSI = {float(_get(ctx, 'drift_overall', 0.0)):.3f} "
+                f">= {psi_alert}; "
+                f"{int(_get(ctx, 'drift_severe', 0))} feature(s) above threshold."
+            ),
+        ),
+        AlertRule(
+            name="DataDrift",
+            severity="warning",
+            description=(
+                f"More than {psi_severe_features} features show severe drift simultaneously."
+            ),
+            predicate=lambda ctx: int(_get(ctx, "drift_severe", 0)) > psi_severe_features,
+            reason=lambda ctx: (
+                f"{int(_get(ctx, 'drift_severe', 0))} features above PSI alert threshold."
+            ),
+        ),
+        AlertRule(
+            name="ModelDegradation",
+            severity="critical",
+            description=f"Production AUPRC fell below {performance_auprc_warn:.2f}.",
+            predicate=lambda ctx: _auprc(ctx) is not None and _auprc(ctx) < performance_auprc_warn,
+            reason=lambda ctx: (
+                f"AUPRC {_auprc(ctx):.3f} on {_n_labelled(ctx)} labelled records "
+                f"(threshold {performance_auprc_warn:.2f})."
+            ),
+        ),
+        AlertRule(
+            name="ModelPerformanceDegraded",
+            severity="warning",
+            description=(
+                f"Production recall fell below {performance_recall_warn:.2f} "
+                "over the latest labelled window."
+            ),
+            predicate=lambda ctx: (
+                _recall(ctx) is not None and _recall(ctx) < performance_recall_warn
+            ),
+            reason=lambda ctx: f"Recall {_recall(ctx):.3f} on {_n_labelled(ctx)} labelled records.",
+        ),
+        AlertRule(
+            name="FraudRateSpike",
+            severity="critical",
+            description=(
+                f"Production fraud rate exceeded {fraud_rate_spike * 100:.0f}% "
+                "(training baseline ~3.5%)."
+            ),
+            predicate=lambda ctx: float(_get(ctx, "production_fraud_rate", 0.0)) > fraud_rate_spike,
+            reason=lambda ctx: (
+                f"Production fraud rate = "
+                f"{float(_get(ctx, 'production_fraud_rate', 0.0)) * 100:.2f}%, "
+                f"reference = {float(_get(ctx, 'reference_fraud_rate', 0.035)) * 100:.2f}%."
+            ),
+        ),
+        AlertRule(
+            name="HighLatency",
+            severity="warning",
+            description=(
+                f"Recent P95 inference latency exceeded the {latency_p95_warn * 1000:.0f}ms budget."
+            ),
+            predicate=lambda ctx: float(_get(ctx, "latency_p95", 0.0)) > latency_p95_warn,
+            reason=lambda ctx: f"P95 latency = {float(_get(ctx, 'latency_p95', 0.0)) * 1000:.1f}ms",
+        ),
+        AlertRule(
+            name="HighErrorRate",
+            severity="critical",
+            description=f"HTTP 5xx rate exceeded {error_rate_warn * 100:.1f}% over the last window.",
+            predicate=lambda ctx: float(_get(ctx, "error_rate", 0.0)) > error_rate_warn,
+            reason=lambda ctx: f"5xx rate = {float(_get(ctx, 'error_rate', 0.0)) * 100:.2f}%",
+        ),
+        AlertRule(
+            name="ShadowChallengerDisagreement",
+            severity="warning",
+            description=(
+                f"Shadow challenger agreement rate fell below {shadow_agreement_warn:.0%}."
+            ),
+            predicate=lambda ctx: (
+                _shadow_agreement(ctx) is not None
+                and _shadow_agreement(ctx) < shadow_agreement_warn
+            ),
+            reason=lambda ctx: (
+                f"Agreement rate = {_shadow_agreement(ctx):.3f} over the recent window."
+            ),
+        ),
+    ]
+
+
+def _recall(ctx: dict[str, Any]) -> float | None:
+    snap = ctx.get("performance")
+    if snap is None:
+        return None
+    if hasattr(snap, "recall") and getattr(snap, "n_labelled", 0):
+        return float(snap.recall)
+    if isinstance(snap, dict):
+        return float(snap.get("recall", 0.0)) if snap.get("n_labelled", 0) else None
+    return None
+
+
+def _n_labelled(ctx: dict[str, Any]) -> int:
+    snap = ctx.get("performance")
+    if snap is None:
+        return 0
+    if hasattr(snap, "n_labelled"):
+        return int(snap.n_labelled)
+    if isinstance(snap, dict):
+        return int(snap.get("n_labelled", 0))
+    return 0
+
+
+def _auprc(ctx: dict[str, Any]) -> float | None:
+    snap = ctx.get("performance")
+    if snap is None:
+        return None
+    if hasattr(snap, "auprc") and getattr(snap, "n_labelled", 0):
+        return None if snap.auprc is None else float(snap.auprc)
+    if isinstance(snap, dict):
+        auprc = snap.get("auprc")
+        n = snap.get("n_labelled", 0)
+        if not n or auprc is None:
+            return None
+        return float(auprc)
+    return None
+
+
+def _shadow_agreement(ctx: dict[str, Any]) -> float | None:
+    summary = ctx.get("shadow")
+    if summary is None:
+        return None
+    if hasattr(summary, "agreement_rate") and getattr(summary, "n_total", 0):
+        return float(summary.agreement_rate)
+    if isinstance(summary, dict):
+        n = summary.get("n_total", 0)
+        if not n:
+            return None
+        return float(summary.get("agreement_rate", 1.0))
+    return None
+
+
+__all__ = [
+    "Alert",
+    "AlertEvaluator",
+    "AlertRule",
+    "AlertSeverity",
+    "default_rules",
+]

--- a/src/fraud_detection/monitoring/drift.py
+++ b/src/fraud_detection/monitoring/drift.py
@@ -1,0 +1,617 @@
+"""Data + concept drift detection (Phase 7).
+
+The :class:`DriftDetector` compares a *reference* distribution (typically the
+training split) against a *current* distribution (a window of recent
+production transactions) and emits a per-feature :class:`FeatureDrift`
+together with an overall :class:`DriftReport`.
+
+Two backends are wired in:
+
+* a pure-NumPy / SciPy implementation -- always available, deterministic,
+  fast enough to run on every refresh tick (PSI, KS, chi-square, JSD);
+* an optional Evidently bridge -- when ``evidently`` is installed we can
+  also emit a rich HTML report. The numpy backend remains the source of
+  truth so the API is consistent in CI.
+
+The default thresholds follow the standard credit-risk practitioner cut-offs:
+
+==========  ==========================
+PSI value   Interpretation
+==========  ==========================
+< 0.10      no significant change
+0.10-0.25   moderate drift -> warn
+>= 0.25     significant drift -> alert
+==========  ==========================
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+import numpy as np
+
+# Optional SciPy / pandas imports -- both ship with the base install but we
+# keep the import guards in case a downstream user strips them.
+try:
+    from scipy import stats as _stats
+
+    _HAVE_SCIPY = True
+except ImportError:  # pragma: no cover -- exercised only in stripped envs
+    _HAVE_SCIPY = False
+
+try:
+    import pandas as pd
+
+    _HAVE_PANDAS = True
+except ImportError:  # pragma: no cover
+    _HAVE_PANDAS = False
+
+
+DriftSeverity = Literal["none", "moderate", "severe"]
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class FeatureDrift:
+    """Drift statistics for a single feature."""
+
+    feature: str
+    kind: Literal["numeric", "categorical"]
+    psi: float
+    ks_statistic: float | None = None
+    ks_pvalue: float | None = None
+    chi2_statistic: float | None = None
+    chi2_pvalue: float | None = None
+    js_divergence: float | None = None
+    mean_shift: float | None = None
+    severity: DriftSeverity = "none"
+    n_reference: int = 0
+    n_current: int = 0
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        return d
+
+
+@dataclass(slots=True)
+class DriftReport:
+    """Overall drift report -- a list of feature reports + summary aggregates."""
+
+    features: list[FeatureDrift] = field(default_factory=list)
+    overall_psi: float = 0.0
+    severity: DriftSeverity = "none"
+    n_reference: int = 0
+    n_current: int = 0
+    generated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    reference_label: str = "training"
+    current_label: str = "production"
+    psi_warn: float = 0.10
+    psi_alert: float = 0.25
+
+    # ----- aggregated views ---------------------------------------------------
+
+    @property
+    def n_features(self) -> int:
+        return len(self.features)
+
+    @property
+    def n_moderate(self) -> int:
+        return sum(1 for f in self.features if f.severity == "moderate")
+
+    @property
+    def n_severe(self) -> int:
+        return sum(1 for f in self.features if f.severity == "severe")
+
+    def top(self, k: int = 10) -> list[FeatureDrift]:
+        return sorted(self.features, key=lambda f: f.psi, reverse=True)[: max(1, k)]
+
+    # ----- serialisation ------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at.isoformat(),
+            "reference_label": self.reference_label,
+            "current_label": self.current_label,
+            "n_reference": self.n_reference,
+            "n_current": self.n_current,
+            "n_features": self.n_features,
+            "n_moderate": self.n_moderate,
+            "n_severe": self.n_severe,
+            "overall_psi": self.overall_psi,
+            "severity": self.severity,
+            "psi_warn": self.psi_warn,
+            "psi_alert": self.psi_alert,
+            "features": [f.to_dict() for f in self.features],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core stats helpers (numpy-only; the SciPy calls are optional add-ons).
+# ---------------------------------------------------------------------------
+
+
+def _to_array(values: Iterable[Any]) -> np.ndarray:
+    arr = np.asarray(list(values), dtype=object)
+    return arr
+
+
+def _coerce_numeric(values: Iterable[Any]) -> np.ndarray:
+    """Coerce an iterable to ``float64``, dropping NaN/None silently."""
+    if _HAVE_PANDAS:
+        # pandas tolerates mixed types better than np.asarray.
+        return pd.to_numeric(pd.Series(list(values)), errors="coerce").dropna().to_numpy()
+    out: list[float] = []
+    for v in values:
+        if v is None:
+            continue
+        try:
+            x = float(v)
+        except (TypeError, ValueError):
+            continue
+        if math.isnan(x):
+            continue
+        out.append(x)
+    return np.asarray(out, dtype=np.float64)
+
+
+def _coerce_categorical(values: Iterable[Any]) -> np.ndarray:
+    out: list[str] = []
+    for v in values:
+        if v is None:
+            continue
+        try:
+            if isinstance(v, float) and math.isnan(v):
+                continue
+        except TypeError:
+            pass
+        out.append(str(v))
+    return np.asarray(out, dtype=object)
+
+
+def population_stability_index(
+    reference: Sequence[float] | np.ndarray,
+    current: Sequence[float] | np.ndarray,
+    *,
+    n_bins: int = 10,
+    eps: float = 1e-6,
+) -> float:
+    """Compute PSI between two 1-D numeric distributions.
+
+    Bins are derived from quantiles of the *reference* distribution so the
+    metric is sensitive to the same buckets you tracked in training. Each
+    bucket gets a small epsilon to avoid log(0) when a class disappears.
+    """
+    ref = np.asarray(reference, dtype=np.float64).ravel()
+    cur = np.asarray(current, dtype=np.float64).ravel()
+    if ref.size == 0 or cur.size == 0:
+        return 0.0
+
+    # Quantile edges from the reference; guarantee strict monotonicity by
+    # bumping repeats by a tiny delta (handles low-cardinality numerics).
+    quantiles = np.linspace(0, 1, n_bins + 1)
+    edges = np.quantile(ref, quantiles)
+    for i in range(1, len(edges)):
+        if edges[i] <= edges[i - 1]:
+            edges[i] = edges[i - 1] + 1e-9
+    edges[0] = -np.inf
+    edges[-1] = np.inf
+
+    ref_hist, _ = np.histogram(ref, bins=edges)
+    cur_hist, _ = np.histogram(cur, bins=edges)
+    ref_p = ref_hist / max(ref.size, 1)
+    cur_p = cur_hist / max(cur.size, 1)
+    ref_p = np.where(ref_p == 0, eps, ref_p)
+    cur_p = np.where(cur_p == 0, eps, cur_p)
+    return float(np.sum((cur_p - ref_p) * np.log(cur_p / ref_p)))
+
+
+def categorical_psi(
+    reference: Sequence[Any],
+    current: Sequence[Any],
+    *,
+    eps: float = 1e-6,
+) -> float:
+    """PSI for categorical distributions using observed categories from reference."""
+    ref = np.asarray(reference, dtype=object).ravel()
+    cur = np.asarray(current, dtype=object).ravel()
+    if ref.size == 0 or cur.size == 0:
+        return 0.0
+    cats = np.unique(np.concatenate([ref, cur]))
+    ref_p = np.array([(ref == c).sum() for c in cats], dtype=np.float64) / max(ref.size, 1)
+    cur_p = np.array([(cur == c).sum() for c in cats], dtype=np.float64) / max(cur.size, 1)
+    ref_p = np.where(ref_p == 0, eps, ref_p)
+    cur_p = np.where(cur_p == 0, eps, cur_p)
+    return float(np.sum((cur_p - ref_p) * np.log(cur_p / ref_p)))
+
+
+def js_divergence(
+    reference: Sequence[float] | np.ndarray,
+    current: Sequence[float] | np.ndarray,
+    *,
+    n_bins: int = 30,
+) -> float:
+    """Jensen-Shannon divergence (base-2) on histogrammed numeric features.
+
+    Symmetric and bounded in [0, 1]; the square root is the metric form.
+    Returned in nats here for consistency with PSI (scale only matters for
+    relative comparison across features).
+    """
+    ref = np.asarray(reference, dtype=np.float64).ravel()
+    cur = np.asarray(current, dtype=np.float64).ravel()
+    if ref.size == 0 or cur.size == 0:
+        return 0.0
+    lo = float(min(ref.min(), cur.min()))
+    hi = float(max(ref.max(), cur.max()))
+    if hi == lo:
+        return 0.0
+    edges = np.linspace(lo, hi, n_bins + 1)
+    rh, _ = np.histogram(ref, bins=edges)
+    ch, _ = np.histogram(cur, bins=edges)
+    rp = rh / max(rh.sum(), 1)
+    cp = ch / max(ch.sum(), 1)
+    m = 0.5 * (rp + cp)
+    eps = 1e-12
+    rp = np.where(rp == 0, eps, rp)
+    cp = np.where(cp == 0, eps, cp)
+    m = np.where(m == 0, eps, m)
+    kl_rm = float(np.sum(rp * np.log(rp / m)))
+    kl_cm = float(np.sum(cp * np.log(cp / m)))
+    return 0.5 * (kl_rm + kl_cm)
+
+
+def ks_test(
+    reference: Sequence[float] | np.ndarray,
+    current: Sequence[float] | np.ndarray,
+) -> tuple[float, float | None]:
+    """Two-sample Kolmogorov-Smirnov test.
+
+    Returns ``(statistic, p_value)``. p-value is ``None`` if SciPy is missing
+    -- the statistic is still a useful drift signal on its own.
+    """
+    ref = np.asarray(reference, dtype=np.float64).ravel()
+    cur = np.asarray(current, dtype=np.float64).ravel()
+    if ref.size == 0 or cur.size == 0:
+        return 0.0, None
+    if _HAVE_SCIPY:
+        res = _stats.ks_2samp(ref, cur)
+        return float(res.statistic), float(res.pvalue)
+    # Numpy fallback -- compute KS statistic by hand on the merged ECDF.
+    merged = np.sort(np.concatenate([ref, cur]))
+    cdf_r = np.searchsorted(np.sort(ref), merged, side="right") / ref.size
+    cdf_c = np.searchsorted(np.sort(cur), merged, side="right") / cur.size
+    return float(np.max(np.abs(cdf_r - cdf_c))), None
+
+
+def chi_square(
+    reference: Sequence[Any],
+    current: Sequence[Any],
+) -> tuple[float, float | None]:
+    """Pearson chi-square goodness-of-fit on categorical distributions."""
+    ref = np.asarray(reference, dtype=object).ravel()
+    cur = np.asarray(current, dtype=object).ravel()
+    if ref.size == 0 or cur.size == 0:
+        return 0.0, None
+    cats = np.unique(np.concatenate([ref, cur]))
+    observed = np.array([(cur == c).sum() for c in cats], dtype=np.float64)
+    expected = np.array([(ref == c).sum() for c in cats], dtype=np.float64)
+    # Scale expected to the current sample size.
+    if expected.sum() > 0:
+        expected = expected * (observed.sum() / expected.sum())
+    expected = np.where(expected == 0, 1e-6, expected)
+    stat = float(np.sum((observed - expected) ** 2 / expected))
+    if _HAVE_SCIPY:
+        dof = max(len(cats) - 1, 1)
+        p = float(1 - _stats.chi2.cdf(stat, dof))
+        return stat, p
+    return stat, None
+
+
+# ---------------------------------------------------------------------------
+# DriftDetector
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DriftDetectorConfig:
+    """Tunable knobs for :class:`DriftDetector`."""
+
+    psi_warn: float = 0.10
+    psi_alert: float = 0.25
+    n_bins: int = 10
+    js_bins: int = 30
+    severity_combine: Literal["max", "mean"] = "max"
+    reference_label: str = "training"
+    current_label: str = "production"
+
+    def severity(self, psi: float) -> DriftSeverity:
+        if psi >= self.psi_alert:
+            return "severe"
+        if psi >= self.psi_warn:
+            return "moderate"
+        return "none"
+
+
+class DriftDetector:
+    """Compute :class:`DriftReport` between a reference and a current sample.
+
+    Parameters
+    ----------
+    reference
+        A mapping from feature name -> 1-D iterable of values seen during
+        training. Numeric columns are kept as-is; everything else is
+        coerced to string.
+    numeric_features, categorical_features
+        Optional explicit splits. If omitted, the detector infers the kind
+        per feature: numerics if every value is castable to float, else
+        categorical.
+    config
+        Threshold + binning configuration. Defaults are the conventional
+        PSI cut-offs (0.10 / 0.25).
+    """
+
+    def __init__(
+        self,
+        reference: Mapping[str, Iterable[Any]],
+        *,
+        numeric_features: Sequence[str] | None = None,
+        categorical_features: Sequence[str] | None = None,
+        config: DriftDetectorConfig | None = None,
+    ) -> None:
+        self.config = config or DriftDetectorConfig()
+        self._numeric_ref: dict[str, np.ndarray] = {}
+        self._categorical_ref: dict[str, np.ndarray] = {}
+
+        explicit_num = set(numeric_features or [])
+        explicit_cat = set(categorical_features or [])
+
+        for feature, values in reference.items():
+            if feature in explicit_num:
+                self._numeric_ref[feature] = _coerce_numeric(values)
+                continue
+            if feature in explicit_cat:
+                self._categorical_ref[feature] = _coerce_categorical(values)
+                continue
+            num = _coerce_numeric(values)
+            raw = _to_array(values)
+            # Heuristic: if a non-trivial portion of values coerced to numeric
+            # without loss, treat the column as numeric. Otherwise -- categorical.
+            if num.size >= max(1, int(0.6 * max(raw.size, 1))):
+                self._numeric_ref[feature] = num
+            else:
+                self._categorical_ref[feature] = _coerce_categorical(values)
+
+    # ------------------------------------------------------------------
+    # introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def numeric_features(self) -> list[str]:
+        return list(self._numeric_ref.keys())
+
+    @property
+    def categorical_features(self) -> list[str]:
+        return list(self._categorical_ref.keys())
+
+    @property
+    def n_reference(self) -> int:
+        if self._numeric_ref:
+            return int(next(iter(self._numeric_ref.values())).size)
+        if self._categorical_ref:
+            return int(next(iter(self._categorical_ref.values())).size)
+        return 0
+
+    # ------------------------------------------------------------------
+    # detection
+    # ------------------------------------------------------------------
+
+    def detect(self, current: Mapping[str, Iterable[Any]]) -> DriftReport:
+        """Compute drift statistics for every feature present in *both* sides."""
+        features: list[FeatureDrift] = []
+        n_current_max = 0
+
+        for name, ref in self._numeric_ref.items():
+            if name not in current:
+                continue
+            cur = _coerce_numeric(current[name])
+            n_current_max = max(n_current_max, int(cur.size))
+            if cur.size == 0:
+                features.append(
+                    FeatureDrift(
+                        feature=name,
+                        kind="numeric",
+                        psi=0.0,
+                        n_reference=int(ref.size),
+                        n_current=0,
+                        notes="no current values",
+                    )
+                )
+                continue
+            psi = population_stability_index(ref, cur, n_bins=self.config.n_bins)
+            ks_stat, ks_p = ks_test(ref, cur)
+            jsd = js_divergence(ref, cur, n_bins=self.config.js_bins)
+            mean_shift = float(cur.mean() - ref.mean()) if ref.size else 0.0
+            features.append(
+                FeatureDrift(
+                    feature=name,
+                    kind="numeric",
+                    psi=float(psi),
+                    ks_statistic=float(ks_stat),
+                    ks_pvalue=ks_p,
+                    js_divergence=float(jsd),
+                    mean_shift=mean_shift,
+                    severity=self.config.severity(psi),
+                    n_reference=int(ref.size),
+                    n_current=int(cur.size),
+                )
+            )
+
+        for name, ref_cat in self._categorical_ref.items():
+            if name not in current:
+                continue
+            cur_cat = _coerce_categorical(current[name])
+            n_current_max = max(n_current_max, int(cur_cat.size))
+            if cur_cat.size == 0:
+                features.append(
+                    FeatureDrift(
+                        feature=name,
+                        kind="categorical",
+                        psi=0.0,
+                        n_reference=int(ref_cat.size),
+                        n_current=0,
+                        notes="no current values",
+                    )
+                )
+                continue
+            psi = categorical_psi(ref_cat, cur_cat)
+            chi2, chi2_p = chi_square(ref_cat, cur_cat)
+            features.append(
+                FeatureDrift(
+                    feature=name,
+                    kind="categorical",
+                    psi=float(psi),
+                    chi2_statistic=float(chi2),
+                    chi2_pvalue=chi2_p,
+                    severity=self.config.severity(psi),
+                    n_reference=int(ref_cat.size),
+                    n_current=int(cur_cat.size),
+                )
+            )
+
+        report = DriftReport(
+            features=features,
+            n_reference=self.n_reference,
+            n_current=n_current_max,
+            reference_label=self.config.reference_label,
+            current_label=self.config.current_label,
+            psi_warn=self.config.psi_warn,
+            psi_alert=self.config.psi_alert,
+        )
+        report.overall_psi = self._overall(features)
+        report.severity = self.config.severity(report.overall_psi)
+        return report
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    def _overall(self, features: list[FeatureDrift]) -> float:
+        if not features:
+            return 0.0
+        vals = [f.psi for f in features]
+        if self.config.severity_combine == "mean":
+            return float(np.mean(vals))
+        return float(np.max(vals))
+
+
+# ---------------------------------------------------------------------------
+# Optional Evidently bridge
+# ---------------------------------------------------------------------------
+
+
+def evidently_html_report(
+    reference: Mapping[str, Iterable[Any]],
+    current: Mapping[str, Iterable[Any]],
+    *,
+    output_path: str | None = None,
+) -> str | None:
+    """Render an Evidently HTML report when the extra is installed.
+
+    Returns the path written (or ``None`` if Evidently is unavailable). We
+    keep this strictly optional -- the numpy backend covers every numeric
+    contract we expose via the API; Evidently is purely a richer view for
+    humans browsing the dashboard.
+    """
+    try:
+        from evidently import Report  # type: ignore[import-not-found]
+        from evidently.presets import DataDriftPreset  # type: ignore[import-not-found]
+    except Exception:  # pragma: no cover -- only exercised when extra missing
+        return None
+
+    if not _HAVE_PANDAS:  # pragma: no cover
+        return None
+
+    ref_df = pd.DataFrame({k: list(v) for k, v in reference.items()})
+    cur_df = pd.DataFrame({k: list(v) for k, v in current.items()})
+
+    report = Report(metrics=[DataDriftPreset()])
+    snapshot = report.run(reference_data=ref_df, current_data=cur_df)
+    if output_path is not None:
+        snapshot.save_html(output_path)
+    return output_path
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers for the two extra drift flavours from the plan:
+#   * label drift            -- production fraud rate vs. training fraud rate
+#   * prediction drift (PSI) -- production score distribution vs. baseline
+# ---------------------------------------------------------------------------
+
+
+def label_drift(
+    production_labels: Iterable[Any],
+    *,
+    reference_rate: float = 0.035,
+) -> dict[str, float]:
+    """Absolute label drift = |production fraud rate - reference|.
+
+    Returns a small dict with ``production_rate``, ``reference_rate`` and
+    ``absolute_drift`` so the caller can feed all three into the monitoring
+    registry in one call.
+    """
+    labels = [int(bool(int(v))) for v in production_labels if v is not None]
+    if not labels:
+        return {
+            "production_rate": 0.0,
+            "reference_rate": float(reference_rate),
+            "absolute_drift": 0.0,
+            "n": 0,
+        }
+    production_rate = float(sum(labels)) / len(labels)
+    return {
+        "production_rate": production_rate,
+        "reference_rate": float(reference_rate),
+        "absolute_drift": abs(production_rate - float(reference_rate)),
+        "n": len(labels),
+    }
+
+
+def prediction_distribution_drift(
+    production_scores: Sequence[float] | np.ndarray,
+    reference_scores: Sequence[float] | np.ndarray,
+    *,
+    n_bins: int = 20,
+) -> float:
+    """PSI between two score distributions.
+
+    Thin wrapper around :func:`population_stability_index` with a default
+    bin count tuned for the [0, 1] probability range.
+    """
+    return population_stability_index(
+        reference=reference_scores, current=production_scores, n_bins=n_bins
+    )
+
+
+__all__ = [
+    "DriftDetector",
+    "DriftDetectorConfig",
+    "DriftReport",
+    "DriftSeverity",
+    "FeatureDrift",
+    "categorical_psi",
+    "chi_square",
+    "evidently_html_report",
+    "js_divergence",
+    "ks_test",
+    "label_drift",
+    "population_stability_index",
+    "prediction_distribution_drift",
+]

--- a/src/fraud_detection/monitoring/performance.py
+++ b/src/fraud_detection/monitoring/performance.py
@@ -1,0 +1,388 @@
+"""Production performance tracker (Phase 7).
+
+Production monitoring for a fraud model is fundamentally a labelled-arrival
+problem: predictions come out in real time, but ground-truth labels show up
+later -- chargebacks land 30-90 days after the transaction. We track the
+rolling window of ``(prediction, label, timestamp)`` triples and recompute
+classification metrics on demand.
+
+The tracker is designed to be safe to import on a CPU-only laptop:
+
+* :mod:`sklearn.metrics` is used when available for AUROC / AUPRC -- otherwise
+  we fall back to the trapezoidal-rule implementation defined here so the
+  public API stays the same.
+* :mod:`mlflow` is optional -- if installed, :meth:`PerformanceTracker.log_mlflow`
+  pushes the latest snapshot under a ``production`` run.
+
+The tracker is bounded (a configurable ``max_records``) so memory stays
+finite even under sustained traffic.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from threading import RLock
+from typing import Any
+
+import numpy as np
+
+try:
+    from sklearn.metrics import (
+        average_precision_score,
+        precision_recall_fscore_support,
+        roc_auc_score,
+    )
+
+    _HAVE_SKLEARN = True
+except ImportError:  # pragma: no cover -- sklearn is in the base deps
+    _HAVE_SKLEARN = False
+
+
+# ---------------------------------------------------------------------------
+# Snapshot
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class PerformanceSnapshot:
+    """Aggregate classification metrics over a window of labelled predictions."""
+
+    n_total: int = 0
+    n_labelled: int = 0
+    n_positive: int = 0
+    n_predicted_positive: int = 0
+    threshold: float = 0.5
+
+    precision: float = 0.0
+    recall: float = 0.0
+    f1: float = 0.0
+    accuracy: float = 0.0
+    auroc: float | None = None
+    auprc: float | None = None
+    brier: float | None = None
+
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    tn: int = 0
+
+    window_start: datetime | None = None
+    window_end: datetime | None = None
+    generated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        for k in ("window_start", "window_end", "generated_at"):
+            v = d.get(k)
+            if isinstance(v, datetime):
+                d[k] = v.isoformat()
+        return d
+
+
+# ---------------------------------------------------------------------------
+# AUC helpers (with pure-numpy fallback)
+# ---------------------------------------------------------------------------
+
+
+def _auroc_numpy(y_true: np.ndarray, y_score: np.ndarray) -> float:
+    """Trapezoidal-rule AUROC -- works without sklearn."""
+    if y_true.size == 0 or len(np.unique(y_true)) < 2:
+        return float("nan")
+    order = np.argsort(-y_score)
+    y = y_true[order]
+    tps = np.cumsum(y == 1)
+    fps = np.cumsum(y == 0)
+    p = (y == 1).sum()
+    n = (y == 0).sum()
+    if p == 0 or n == 0:
+        return float("nan")
+    tpr = tps / p
+    fpr = fps / n
+    tpr = np.concatenate([[0.0], tpr])
+    fpr = np.concatenate([[0.0], fpr])
+    return float(np.trapezoid(tpr, fpr)) if hasattr(np, "trapezoid") else float(np.trapz(tpr, fpr))
+
+
+def _auprc_numpy(y_true: np.ndarray, y_score: np.ndarray) -> float:
+    """Average-precision via running precision-recall (sklearn-compatible shape)."""
+    if y_true.size == 0 or (y_true == 1).sum() == 0:
+        return float("nan")
+    order = np.argsort(-y_score)
+    y = y_true[order]
+    tps = np.cumsum(y == 1)
+    fps = np.cumsum(y == 0)
+    precision = tps / (tps + fps + 1e-12)
+    recall = tps / max((y == 1).sum(), 1)
+    # AP = sum_i (recall_i - recall_{i-1}) * precision_i  (sklearn definition)
+    recall_prev = np.concatenate([[0.0], recall[:-1]])
+    return float(np.sum((recall - recall_prev) * precision))
+
+
+def auroc(y_true: Iterable[int], y_score: Iterable[float]) -> float:
+    yt = np.asarray(list(y_true), dtype=np.int64)
+    ys = np.asarray(list(y_score), dtype=np.float64)
+    if _HAVE_SKLEARN and yt.size and len(np.unique(yt)) == 2:
+        try:
+            return float(roc_auc_score(yt, ys))
+        except Exception:  # pragma: no cover -- degraded labels
+            return float("nan")
+    return _auroc_numpy(yt, ys)
+
+
+def auprc(y_true: Iterable[int], y_score: Iterable[float]) -> float:
+    yt = np.asarray(list(y_true), dtype=np.int64)
+    ys = np.asarray(list(y_score), dtype=np.float64)
+    if _HAVE_SKLEARN and yt.size and (yt == 1).any():
+        try:
+            return float(average_precision_score(yt, ys))
+        except Exception:  # pragma: no cover
+            return float("nan")
+    return _auprc_numpy(yt, ys)
+
+
+# ---------------------------------------------------------------------------
+# PerformanceTracker
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _Record:
+    transaction_id: int | str
+    score: float
+    timestamp: datetime
+    label: int | None = None
+
+
+class PerformanceTracker:
+    """Bounded ring-buffer of (score, label, timestamp) records.
+
+    Designed to be safe for concurrent use from the FastAPI app's request
+    handlers (predictions append) and a background job (labels merge in
+    from chargeback events). Both paths take the same lock; metric
+    computation is read-only and copies the buffer first.
+
+    Parameters
+    ----------
+    max_records
+        Hard cap on the ring buffer. Older records are evicted when full.
+    threshold
+        Decision threshold for precision/recall/F1. AUC metrics ignore it.
+    """
+
+    def __init__(self, *, max_records: int = 5_000, threshold: float = 0.7) -> None:
+        self._records: deque[_Record] = deque(maxlen=max_records)
+        self._lock = RLock()
+        self.threshold = float(threshold)
+
+    # ------------------------------------------------------------------
+    # writers
+    # ------------------------------------------------------------------
+
+    def record_prediction(
+        self,
+        transaction_id: int | str,
+        score: float,
+        *,
+        timestamp: datetime | None = None,
+        label: int | None = None,
+    ) -> None:
+        """Append a prediction. ``label`` may be supplied later via :meth:`record_label`."""
+        with self._lock:
+            self._records.append(
+                _Record(
+                    transaction_id=transaction_id,
+                    score=float(score),
+                    timestamp=timestamp or datetime.now(timezone.utc),
+                    label=None if label is None else int(label),
+                )
+            )
+
+    def record_label(self, transaction_id: int | str, label: int) -> bool:
+        """Attach a ground-truth label to an existing record.
+
+        Returns ``True`` if the record was found, ``False`` if it has
+        already evicted from the bounded buffer (a common, acceptable
+        outcome when labels arrive months after the prediction).
+        """
+        with self._lock:
+            for r in reversed(self._records):
+                if r.transaction_id == transaction_id:
+                    r.label = int(label)
+                    return True
+        return False
+
+    def reset(self) -> None:
+        with self._lock:
+            self._records.clear()
+
+    # ------------------------------------------------------------------
+    # introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def n_records(self) -> int:
+        with self._lock:
+            return len(self._records)
+
+    @property
+    def n_labelled(self) -> int:
+        with self._lock:
+            return sum(1 for r in self._records if r.label is not None)
+
+    # ------------------------------------------------------------------
+    # readers
+    # ------------------------------------------------------------------
+
+    def snapshot(
+        self,
+        *,
+        window: timedelta | None = None,
+        now: datetime | None = None,
+    ) -> PerformanceSnapshot:
+        """Compute classification metrics over the requested window.
+
+        Parameters
+        ----------
+        window
+            Only consider records with ``timestamp >= now - window``. When
+            ``None`` -- use the entire buffer.
+        now
+            Reference time. Defaults to ``datetime.now(timezone.utc)``.
+        """
+        now = now or datetime.now(timezone.utc)
+        with self._lock:
+            records = list(self._records)
+
+        if window is not None:
+            cutoff = now - window
+            records = [r for r in records if r.timestamp >= cutoff]
+
+        n_total = len(records)
+        labelled = [r for r in records if r.label is not None]
+        n_labelled = len(labelled)
+
+        if not labelled:
+            return PerformanceSnapshot(
+                n_total=n_total,
+                n_labelled=0,
+                threshold=self.threshold,
+                window_start=records[0].timestamp if records else None,
+                window_end=records[-1].timestamp if records else None,
+            )
+
+        y_true = np.array([r.label for r in labelled], dtype=np.int64)
+        y_score = np.array([r.score for r in labelled], dtype=np.float64)
+        y_pred = (y_score >= self.threshold).astype(np.int64)
+
+        tp = int(((y_pred == 1) & (y_true == 1)).sum())
+        fp = int(((y_pred == 1) & (y_true == 0)).sum())
+        fn = int(((y_pred == 0) & (y_true == 1)).sum())
+        tn = int(((y_pred == 0) & (y_true == 0)).sum())
+
+        precision = tp / max(tp + fp, 1)
+        recall = tp / max(tp + fn, 1)
+        f1 = (2 * precision * recall) / max(precision + recall, 1e-12) if (tp + fp + fn) else 0.0
+        accuracy = (tp + tn) / max(n_labelled, 1)
+
+        # sklearn returns the same numbers but its support array is convenient
+        # for sanity-checking when present; falls back to manual otherwise.
+        if _HAVE_SKLEARN and len(np.unique(y_true)) == 2:
+            try:
+                precision_sk, recall_sk, f1_sk, _ = precision_recall_fscore_support(
+                    y_true, y_pred, average="binary", zero_division=0
+                )
+                precision = float(precision_sk)
+                recall = float(recall_sk)
+                f1 = float(f1_sk)
+            except Exception:  # pragma: no cover -- degraded class distribution
+                pass
+
+        au_roc = auroc(y_true, y_score) if len(np.unique(y_true)) == 2 else None
+        au_prc = auprc(y_true, y_score) if (y_true == 1).any() else None
+        if au_roc is not None and math.isnan(au_roc):
+            au_roc = None
+        if au_prc is not None and math.isnan(au_prc):
+            au_prc = None
+
+        brier = float(np.mean((y_score - y_true) ** 2))
+
+        return PerformanceSnapshot(
+            n_total=n_total,
+            n_labelled=n_labelled,
+            n_positive=int((y_true == 1).sum()),
+            n_predicted_positive=int(y_pred.sum()),
+            threshold=self.threshold,
+            precision=float(precision),
+            recall=float(recall),
+            f1=float(f1),
+            accuracy=float(accuracy),
+            auroc=au_roc,
+            auprc=au_prc,
+            brier=brier,
+            tp=tp,
+            fp=fp,
+            fn=fn,
+            tn=tn,
+            window_start=records[0].timestamp if records else None,
+            window_end=records[-1].timestamp if records else None,
+        )
+
+    # ------------------------------------------------------------------
+    # exports
+    # ------------------------------------------------------------------
+
+    def log_mlflow(
+        self,
+        snapshot: PerformanceSnapshot,
+        *,
+        run_name: str = "production",
+        experiment: str = "meshwatch-production",
+    ) -> bool:
+        """Push a snapshot to MLflow as a fresh run inside an experiment.
+
+        Returns ``True`` when MLflow is installed *and* a tracking server is
+        reachable (or a local SQLite store is writable). Returns ``False``
+        silently otherwise so callers can keep operating in degraded mode.
+        """
+        try:  # pragma: no cover -- exercised in integration env only
+            import mlflow
+
+            mlflow.set_experiment(experiment)
+            with mlflow.start_run(run_name=run_name):
+                params = {
+                    "threshold": snapshot.threshold,
+                    "n_total": snapshot.n_total,
+                    "n_labelled": snapshot.n_labelled,
+                }
+                for k, v in params.items():
+                    mlflow.log_param(k, v)
+                metrics = {
+                    "precision": snapshot.precision,
+                    "recall": snapshot.recall,
+                    "f1": snapshot.f1,
+                    "accuracy": snapshot.accuracy,
+                    "brier": snapshot.brier or 0.0,
+                }
+                if snapshot.auroc is not None:
+                    metrics["auroc"] = snapshot.auroc
+                if snapshot.auprc is not None:
+                    metrics["auprc"] = snapshot.auprc
+                for k, v in metrics.items():
+                    if v is None or (isinstance(v, float) and math.isnan(v)):
+                        continue
+                    mlflow.log_metric(k, float(v))
+            return True
+        except Exception:
+            return False
+
+
+__all__ = [
+    "PerformanceSnapshot",
+    "PerformanceTracker",
+    "auprc",
+    "auroc",
+]

--- a/src/fraud_detection/monitoring/registry.py
+++ b/src/fraud_detection/monitoring/registry.py
@@ -1,0 +1,324 @@
+"""Extended Prometheus metrics for Phase 7.
+
+The serving middleware already exposes per-request metrics under the
+``meshwatch_http_*`` and ``meshwatch_predictions_*`` namespaces. Phase 7
+adds three more groups:
+
+* **drift** -- the latest overall + per-feature PSI; gauges are convenient
+  because Prometheus alerts on absolute values, not deltas.
+* **performance** -- the latest precision/recall/F1/AUROC snapshot.
+* **agent** -- per-tool invocation counts + latency histograms; the
+  Phase 5 investigator publishes here via :meth:`MonitoringMetrics.record_agent_run`.
+
+All groups degrade to no-ops when ``prometheus-client`` is missing, mirroring
+the contract of the serving middleware. The single :class:`MonitoringMetrics`
+instance attaches itself to the registry that already backs ``/api/v1/metrics``,
+so a single scrape gives operators the full picture.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Protocol
+
+from fraud_detection.serving.middleware import metrics as serving_metrics
+
+
+class _MetricLike(Protocol):
+    def labels(self, *args: Any, **kwargs: Any) -> _MetricLike: ...
+    def inc(self, *args: Any, **kwargs: Any) -> None: ...
+    def dec(self, *args: Any, **kwargs: Any) -> None: ...
+    def observe(self, *args: Any, **kwargs: Any) -> None: ...
+    def set(self, *args: Any, **kwargs: Any) -> None: ...
+
+
+class _NoopMetric:
+    """Shared no-op used when prometheus_client is missing."""
+
+    def labels(self, *args: Any, **kwargs: Any) -> _NoopMetric:
+        return self
+
+    def inc(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def dec(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def observe(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def set(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class MonitoringMetrics:
+    """Lazily-constructed Prometheus collectors for the monitoring layer.
+
+    Constructing this class twice on the same process is safe -- it reuses
+    the shared registry from :mod:`fraud_detection.serving.middleware`,
+    so the second call simply re-fetches the existing collectors.
+    """
+
+    def __init__(self) -> None:
+        self._enabled = bool(getattr(serving_metrics, "_enabled", False))
+        registry = getattr(serving_metrics, "registry", None)
+
+        if not self._enabled or registry is None:
+            self.drift_overall = _NoopMetric()
+            self.drift_feature = _NoopMetric()
+            self.drift_features_severe = _NoopMetric()
+            self.drift_features_moderate = _NoopMetric()
+            self.label_drift = _NoopMetric()
+            self.prediction_distribution_drift = _NoopMetric()
+            self.production_fraud_rate = _NoopMetric()
+            self.performance_precision = _NoopMetric()
+            self.performance_recall = _NoopMetric()
+            self.performance_f1 = _NoopMetric()
+            self.performance_auroc = _NoopMetric()
+            self.performance_auprc = _NoopMetric()
+            self.performance_n_labelled = _NoopMetric()
+            self.agent_invocations = _NoopMetric()
+            self.agent_tool_invocations = _NoopMetric()
+            self.agent_latency = _NoopMetric()
+            self.shadow_decisions = _NoopMetric()
+            self.shadow_agreements = _NoopMetric()
+            self.shadow_score_delta = _NoopMetric()
+            self.shadow_challenger_latency = _NoopMetric()
+            return
+
+        from prometheus_client import (
+            Counter,
+            Gauge,
+            Histogram,
+        )
+
+        def _get_or_create(factory_cls: Any, name: str, *args: Any, **kwargs: Any) -> Any:
+            """Return an existing collector if already in the registry."""
+            existing = self._existing_collector(name)
+            if existing is not None:
+                return existing
+            return factory_cls(name, *args, registry=registry, **kwargs)
+
+        self.drift_overall = _get_or_create(
+            Gauge,
+            "meshwatch_drift_psi_overall",
+            "Overall PSI between the reference (training) and current production windows",
+        )
+        self.drift_feature = _get_or_create(
+            Gauge,
+            "meshwatch_drift_psi_feature",
+            "Per-feature PSI",
+            ["feature", "kind"],
+        )
+        self.drift_features_severe = _get_or_create(
+            Gauge,
+            "meshwatch_drift_features_severe",
+            "Number of features with PSI >= alert threshold",
+        )
+        self.drift_features_moderate = _get_or_create(
+            Gauge,
+            "meshwatch_drift_features_moderate",
+            "Number of features with PSI in [warn, alert)",
+        )
+        self.performance_precision = _get_or_create(
+            Gauge, "meshwatch_performance_precision", "Production precision at the alert threshold"
+        )
+        self.performance_recall = _get_or_create(
+            Gauge, "meshwatch_performance_recall", "Production recall at the alert threshold"
+        )
+        self.performance_f1 = _get_or_create(
+            Gauge, "meshwatch_performance_f1", "Production F1 at the alert threshold"
+        )
+        self.performance_auroc = _get_or_create(
+            Gauge, "meshwatch_performance_auroc", "Production AUROC over the labelled window"
+        )
+        self.performance_auprc = _get_or_create(
+            Gauge,
+            "meshwatch_performance_auprc",
+            "Production AUPRC (average precision) over the labelled window",
+        )
+        self.performance_n_labelled = _get_or_create(
+            Gauge,
+            "meshwatch_performance_n_labelled",
+            "Number of labelled predictions in the current window",
+        )
+        self.agent_invocations = _get_or_create(
+            Counter,
+            "meshwatch_agent_invocations_total",
+            "Agent investigations completed",
+            ["risk_level", "status"],
+        )
+        self.agent_tool_invocations = _get_or_create(
+            Counter,
+            "meshwatch_agent_tool_invocations_total",
+            "Tool invocations across all agent runs",
+            ["tool", "status"],
+        )
+        self.agent_latency = _get_or_create(
+            Histogram,
+            "meshwatch_agent_run_latency_seconds",
+            "Agent end-to-end run latency",
+            ["risk_level"],
+            buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0),
+        )
+
+        # Label / prediction drift -- the plan calls out three drift types:
+        # data drift (handled by drift_overall + drift_feature), label drift
+        # (production fraud rate vs. training fraud rate), and prediction
+        # distribution drift (score-distribution PSI champion-vs-baseline).
+        self.label_drift = _get_or_create(
+            Gauge,
+            "meshwatch_label_drift",
+            "Absolute difference between production and training fraud rates",
+        )
+        self.prediction_distribution_drift = _get_or_create(
+            Gauge,
+            "meshwatch_prediction_distribution_drift",
+            "PSI between production and reference score distributions",
+        )
+        self.production_fraud_rate = _get_or_create(
+            Gauge,
+            "meshwatch_production_fraud_rate",
+            "Rolling production fraud rate (predictions above threshold / total)",
+        )
+
+        # Shadow deployment metrics.
+        self.shadow_decisions = _get_or_create(
+            Counter,
+            "meshwatch_shadow_decisions_total",
+            "Shadow champion/challenger decisions",
+            ["champion_model", "challenger_model", "outcome"],
+        )
+        self.shadow_agreements = _get_or_create(
+            Gauge,
+            "meshwatch_shadow_agreement_rate",
+            "Rolling champion/challenger agreement rate (last window)",
+        )
+        self.shadow_score_delta = _get_or_create(
+            Histogram,
+            "meshwatch_shadow_score_delta",
+            "Absolute score delta between champion and challenger",
+            buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0),
+        )
+        self.shadow_challenger_latency = _get_or_create(
+            Histogram,
+            "meshwatch_shadow_challenger_latency_seconds",
+            "Challenger inference latency (off the request hot path)",
+            buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0),
+        )
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _existing_collector(name: str) -> Any | None:
+        registry = getattr(serving_metrics, "registry", None)
+        if registry is None:
+            return None
+        # CollectorRegistry exposes ``_names_to_collectors`` (private but stable
+        # across the 0.* line of prometheus-client). We poke it so that
+        # re-instantiating MonitoringMetrics inside tests doesn't blow up
+        # with a "Duplicated timeseries" error.
+        names_to_collectors = getattr(registry, "_names_to_collectors", {})
+        return names_to_collectors.get(name)
+
+    # ------------------------------------------------------------------
+    # high-level writers
+    # ------------------------------------------------------------------
+
+    def update_drift(self, report: Any) -> None:
+        """Update the drift gauges from a :class:`DriftReport`."""
+        from fraud_detection.monitoring.drift import DriftReport
+
+        if not isinstance(report, DriftReport):
+            return
+        self.drift_overall.set(float(report.overall_psi))
+        self.drift_features_severe.set(int(report.n_severe))
+        self.drift_features_moderate.set(int(report.n_moderate))
+        for f in report.features:
+            self.drift_feature.labels(f.feature, f.kind).set(float(f.psi))
+
+    def update_performance(self, snapshot: Any) -> None:
+        """Update the performance gauges from a :class:`PerformanceSnapshot`."""
+        from fraud_detection.monitoring.performance import PerformanceSnapshot
+
+        if not isinstance(snapshot, PerformanceSnapshot):
+            return
+        self.performance_precision.set(float(snapshot.precision))
+        self.performance_recall.set(float(snapshot.recall))
+        self.performance_f1.set(float(snapshot.f1))
+        self.performance_n_labelled.set(int(snapshot.n_labelled))
+        if snapshot.auroc is not None:
+            self.performance_auroc.set(float(snapshot.auroc))
+        if snapshot.auprc is not None:
+            self.performance_auprc.set(float(snapshot.auprc))
+
+    def record_shadow_decision(self, decision: Any) -> None:
+        """Update shadow-deployment counters + histograms.
+
+        Accepts a :class:`ShadowDecision` from
+        :mod:`fraud_detection.monitoring.shadow`. We import lazily so this
+        registry can be loaded without the shadow module having been imported.
+        """
+        from fraud_detection.monitoring.shadow import ShadowDecision
+
+        if not isinstance(decision, ShadowDecision):
+            return
+        outcome = "agree" if decision.agreement else "disagree"
+        self.shadow_decisions.labels(
+            decision.champion_model, decision.challenger_model, outcome
+        ).inc()
+        self.shadow_score_delta.observe(abs(float(decision.score_delta)))
+        self.shadow_challenger_latency.observe(float(decision.challenger_latency_ms) / 1000.0)
+
+    def update_shadow_summary(self, summary: Any) -> None:
+        """Push the rolling shadow summary onto the agreement-rate gauge."""
+        from fraud_detection.monitoring.shadow import ShadowSummary
+
+        if not isinstance(summary, ShadowSummary):
+            return
+        self.shadow_agreements.set(float(summary.agreement_rate))
+
+    def update_label_drift(self, *, production_rate: float, reference_rate: float) -> None:
+        """Update label-drift gauges (used by drift_report + monitor.py)."""
+        self.production_fraud_rate.set(float(production_rate))
+        self.label_drift.set(float(abs(production_rate - reference_rate)))
+
+    def update_prediction_distribution_drift(self, psi: float) -> None:
+        """Update the prediction-distribution PSI gauge."""
+        self.prediction_distribution_drift.set(float(psi))
+
+    def record_agent_run(
+        self,
+        *,
+        risk_level: str,
+        latency_seconds: float,
+        status: str = "ok",
+        tool_calls: Iterable[tuple[str, str]] | None = None,
+    ) -> None:
+        """Record a single agent investigation.
+
+        Parameters
+        ----------
+        risk_level
+            LOW / MEDIUM / HIGH / CRITICAL.
+        latency_seconds
+            Wall-clock seconds for the full LangGraph run.
+        status
+            ``"ok"`` or ``"error"``.
+        tool_calls
+            Iterable of ``(tool_name, "ok"|"error")`` pairs to count.
+        """
+        self.agent_invocations.labels(risk_level, status).inc()
+        self.agent_latency.labels(risk_level).observe(max(0.0, float(latency_seconds)))
+        if tool_calls is not None:
+            for tool, tool_status in tool_calls:
+                self.agent_tool_invocations.labels(tool, tool_status).inc()
+
+
+# Module-level singleton -- safe to import everywhere.
+monitoring_metrics = MonitoringMetrics()
+
+
+__all__ = ["MonitoringMetrics", "monitoring_metrics"]

--- a/src/fraud_detection/monitoring/reports.py
+++ b/src/fraud_detection/monitoring/reports.py
@@ -1,0 +1,224 @@
+"""Drift report serialisation -- JSON + self-contained HTML.
+
+The HTML renderer ships with all assets inlined so reports can be emailed,
+attached to tickets, or served behind ``nginx`` without rebuilding the
+asset pipeline. We deliberately keep the template tiny (no JS, no
+external fonts) so the bundle is well under 50 KB even for the full
+119-feature snapshot.
+"""
+
+from __future__ import annotations
+
+import html as _html
+import json
+from pathlib import Path
+from typing import Any
+
+from fraud_detection.monitoring.drift import DriftReport, FeatureDrift
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+
+
+def report_to_json(report: DriftReport, *, indent: int = 2) -> str:
+    return json.dumps(report.to_dict(), indent=indent, sort_keys=False)
+
+
+def write_json(report: DriftReport, path: str | Path) -> Path:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(report_to_json(report), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# HTML
+# ---------------------------------------------------------------------------
+
+_SEVERITY_CLASS = {
+    "none": "ok",
+    "moderate": "warn",
+    "severe": "alert",
+}
+
+_HTML_STYLES = """
+:root {
+    --bg: #0b1020;
+    --panel: #131a30;
+    --panel-2: #1b2440;
+    --text: #e6e8ef;
+    --muted: #8892a6;
+    --ok: #16a34a;
+    --warn: #d97706;
+    --alert: #dc2626;
+    --accent: #6366f1;
+}
+* { box-sizing: border-box; }
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+header {
+    padding: 24px 32px;
+    background: linear-gradient(180deg, #182142 0%, #0f1530 100%);
+    border-bottom: 1px solid #1e2848;
+}
+h1 { margin: 0 0 6px 0; font-size: 20px; }
+.subtitle { color: var(--muted); font-size: 13px; }
+.container { padding: 24px 32px; }
+.summary {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(160px, 1fr));
+    gap: 12px;
+    margin-bottom: 24px;
+}
+.card {
+    background: var(--panel);
+    border: 1px solid #1e2848;
+    border-radius: 8px;
+    padding: 14px 16px;
+}
+.card .label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; }
+.card .value { font-size: 22px; font-weight: 600; margin-top: 4px; }
+.severity {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+.severity.ok    { background: rgba(22, 163, 74, 0.15);  color: var(--ok); }
+.severity.warn  { background: rgba(217, 119, 6, 0.18);  color: var(--warn); }
+.severity.alert { background: rgba(220, 38, 38, 0.18);  color: var(--alert); }
+table { width: 100%; border-collapse: collapse; background: var(--panel); border-radius: 8px; overflow: hidden; }
+th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid #1e2848; font-variant-numeric: tabular-nums; }
+th { background: var(--panel-2); color: var(--muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; font-size: 11px; }
+tr:last-child td { border-bottom: none; }
+.bar { display: inline-block; height: 6px; background: linear-gradient(90deg, var(--ok) 0%, var(--warn) 60%, var(--alert) 100%); border-radius: 3px; }
+.muted { color: var(--muted); }
+footer { padding: 16px 32px; color: var(--muted); font-size: 12px; }
+""".strip()
+
+
+def _fmt(v: Any, *, digits: int = 4) -> str:
+    if v is None:
+        return "<span class='muted'>--</span>"
+    if isinstance(v, float):
+        if v != v:  # NaN
+            return "<span class='muted'>--</span>"
+        return f"{v:.{digits}f}"
+    return _html.escape(str(v))
+
+
+def _feature_row(f: FeatureDrift, *, max_psi: float) -> str:
+    klass = _SEVERITY_CLASS.get(f.severity, "ok")
+    width = min(100, int((f.psi / max(max_psi, 1e-9)) * 100)) if f.psi > 0 else 1
+    return (
+        "<tr>"
+        f"<td>{_html.escape(f.feature)}</td>"
+        f"<td>{_html.escape(f.kind)}</td>"
+        f"<td>{_fmt(f.psi)}</td>"
+        f"<td><span class='bar' style='width:{width}%'></span></td>"
+        f"<td>{_fmt(f.ks_statistic)}</td>"
+        f"<td>{_fmt(f.ks_pvalue)}</td>"
+        f"<td>{_fmt(f.chi2_statistic, digits=2)}</td>"
+        f"<td>{_fmt(f.js_divergence)}</td>"
+        f"<td>{_fmt(f.mean_shift)}</td>"
+        f"<td><span class='severity {klass}'>{_html.escape(f.severity)}</span></td>"
+        f"<td class='muted'>{f.n_reference} / {f.n_current}</td>"
+        "</tr>"
+    )
+
+
+def report_to_html(report: DriftReport, *, title: str = "Meshwatch drift report") -> str:
+    """Render a self-contained HTML report. No external assets, no JS."""
+    klass = _SEVERITY_CLASS.get(report.severity, "ok")
+    max_psi = max((f.psi for f in report.features), default=0.0)
+    feature_rows = "\n".join(_feature_row(f, max_psi=max_psi) for f in report.top(50))
+    body = f"""
+<header>
+    <h1>{_html.escape(title)}</h1>
+    <div class="subtitle">
+        Reference: <strong>{_html.escape(report.reference_label)}</strong> ({report.n_reference} rows)
+        &nbsp;|&nbsp; Current: <strong>{_html.escape(report.current_label)}</strong> ({report.n_current} rows)
+        &nbsp;|&nbsp; Generated {report.generated_at.isoformat()}
+    </div>
+</header>
+<div class="container">
+    <section class="summary">
+        <div class="card">
+            <div class="label">Overall PSI</div>
+            <div class="value">{report.overall_psi:.4f}</div>
+        </div>
+        <div class="card">
+            <div class="label">Severity</div>
+            <div class="value"><span class="severity {klass}">{_html.escape(report.severity)}</span></div>
+        </div>
+        <div class="card">
+            <div class="label">Moderate features</div>
+            <div class="value">{report.n_moderate}</div>
+        </div>
+        <div class="card">
+            <div class="label">Severe features</div>
+            <div class="value">{report.n_severe}</div>
+        </div>
+    </section>
+    <h2 style="margin: 8px 0 12px 0;">Top {min(50, report.n_features)} features by PSI</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Feature</th>
+                <th>Kind</th>
+                <th>PSI</th>
+                <th>Magnitude</th>
+                <th>KS</th>
+                <th>KS p-value</th>
+                <th>χ²</th>
+                <th>JSD</th>
+                <th>Mean Δ</th>
+                <th>Severity</th>
+                <th>n ref / cur</th>
+            </tr>
+        </thead>
+        <tbody>{feature_rows}</tbody>
+    </table>
+</div>
+<footer>
+    PSI warn threshold {report.psi_warn:.2f} &middot; PSI alert threshold {report.psi_alert:.2f}
+    &middot; Meshwatch v0.7.0-mlops
+</footer>
+""".strip()
+    return (
+        "<!doctype html>\n"
+        "<html lang='en'>\n"
+        "<head>\n"
+        f"<meta charset='utf-8'><title>{_html.escape(title)}</title>\n"
+        f"<style>{_HTML_STYLES}</style>\n"
+        "</head>\n"
+        "<body>\n"
+        f"{body}\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def write_html(report: DriftReport, path: str | Path, *, title: str | None = None) -> Path:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        report_to_html(report, title=title or "Meshwatch drift report"),
+        encoding="utf-8",
+    )
+    return p
+
+
+__all__ = [
+    "report_to_html",
+    "report_to_json",
+    "write_html",
+    "write_json",
+]

--- a/src/fraud_detection/monitoring/shadow.py
+++ b/src/fraud_detection/monitoring/shadow.py
@@ -1,0 +1,317 @@
+"""Shadow / champion-vs-challenger deployment (Phase 7).
+
+The plan's MLOps story includes a "shadow deploy" lane: every production
+request is served by the *champion* model, but a *challenger* model
+scores the same request in the background. We never block on the
+challenger -- it just logs its score, the delta vs. champion, and any
+disagreement so MLOps engineers can decide whether to promote.
+
+This module provides:
+
+* :class:`ShadowDecision` -- the per-request log record.
+* :class:`ShadowDeployment` -- holds a champion :class:`FraudPredictor`,
+  an optional challenger predictor, and a bounded history. Exposes
+  ``score()`` that always returns the champion's result and kicks off a
+  best-effort challenger scoring in a background thread.
+* Prometheus metrics: challenger run count, agreement rate,
+  score-delta histogram.
+
+Why threads (rather than asyncio)? The :class:`FraudPredictor` hot path
+is mostly numpy + XGBoost -- CPU-bound, no event loop yield -- so we
+push challenger inference off the request thread with a tiny
+:class:`ThreadPoolExecutor` and never wait on the result. If the
+challenger blows past a budget (default 100ms) we drop the record.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from fraud_detection.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from fraud_detection.serving.predictor import FraudPredictor
+    from fraud_detection.serving.schemas import FraudPrediction, TransactionRequest
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Per-request record
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ShadowDecision:
+    """One champion/challenger comparison."""
+
+    transaction_id: int | str
+    champion_score: float
+    challenger_score: float
+    score_delta: float
+    champion_label: bool
+    challenger_label: bool
+    agreement: bool
+    champion_model: str
+    challenger_model: str
+    champion_latency_ms: float
+    challenger_latency_ms: float
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        if isinstance(d["timestamp"], datetime):
+            d["timestamp"] = d["timestamp"].isoformat()
+        return d
+
+
+@dataclass(slots=True)
+class ShadowSummary:
+    """Aggregate stats over a window of decisions."""
+
+    n_total: int = 0
+    n_agreement: int = 0
+    n_disagreement: int = 0
+    agreement_rate: float = 0.0
+    mean_score_delta: float = 0.0
+    max_score_delta: float = 0.0
+    challenger_skipped: int = 0
+    challenger_failed: int = 0
+    champion_model: str = ""
+    challenger_model: str = ""
+    window_start: datetime | None = None
+    window_end: datetime | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        for k in ("window_start", "window_end"):
+            v = d.get(k)
+            if isinstance(v, datetime):
+                d[k] = v.isoformat()
+        return d
+
+
+# ---------------------------------------------------------------------------
+# ShadowDeployment
+# ---------------------------------------------------------------------------
+
+
+class ShadowDeployment:
+    """Champion/challenger orchestrator.
+
+    Parameters
+    ----------
+    champion
+        The :class:`FraudPredictor` that owns the production hot path.
+        Every call to :meth:`score` returns its prediction unchanged.
+    challenger
+        Optional second :class:`FraudPredictor`. When supplied, every
+        request is also scored by the challenger off the request thread.
+        Setting ``None`` (or calling :meth:`detach_challenger`) disables
+        the shadow lane.
+    max_records
+        Bounded history for :meth:`recent_decisions`.
+    challenger_budget_ms
+        Drop the challenger run if it exceeds this budget.
+    threshold
+        Decision threshold used to compute the per-request agreement
+        bit. Defaults to the champion's threshold.
+    """
+
+    def __init__(
+        self,
+        *,
+        champion: FraudPredictor,
+        challenger: FraudPredictor | None = None,
+        max_records: int = 1000,
+        challenger_budget_ms: float = 100.0,
+        threshold: float | None = None,
+    ) -> None:
+        self.champion = champion
+        self.challenger = challenger
+        self.threshold = float(threshold if threshold is not None else champion.threshold)
+        self.challenger_budget_ms = float(challenger_budget_ms)
+
+        self._records: deque[ShadowDecision] = deque(maxlen=max_records)
+        self._skipped = 0
+        self._failed = 0
+        self._lock = threading.RLock()
+        self._executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="shadow")
+
+    # ------------------------------------------------------------------
+    # configuration
+    # ------------------------------------------------------------------
+
+    def attach_challenger(self, challenger: FraudPredictor) -> None:
+        with self._lock:
+            self.challenger = challenger
+
+    def detach_challenger(self) -> None:
+        with self._lock:
+            self.challenger = None
+
+    def reset(self) -> None:
+        with self._lock:
+            self._records.clear()
+            self._skipped = 0
+            self._failed = 0
+
+    @property
+    def n_records(self) -> int:
+        with self._lock:
+            return len(self._records)
+
+    @property
+    def enabled(self) -> bool:
+        return self.challenger is not None
+
+    # ------------------------------------------------------------------
+    # scoring
+    # ------------------------------------------------------------------
+
+    def score(self, request: TransactionRequest) -> FraudPrediction:
+        """Score with the champion (synchronous) and shadow-score with the
+        challenger (asynchronous, best-effort)."""
+        t0 = time.perf_counter()
+        result = self.champion.predict_one(request)
+        champion_latency_ms = (time.perf_counter() - t0) * 1000
+
+        if self.challenger is None:
+            return result
+
+        # Best-effort challenger run. We deliberately do NOT block on the
+        # future -- it must never delay the hot path.
+        try:
+            self._executor.submit(
+                self._run_challenger,
+                request,
+                result.fraud_score,
+                champion_latency_ms,
+            )
+        except RuntimeError:
+            # Executor shutting down; skip silently.
+            with self._lock:
+                self._skipped += 1
+
+        return result
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    def _run_challenger(
+        self,
+        request: TransactionRequest,
+        champion_score: float,
+        champion_latency_ms: float,
+    ) -> None:
+        if self.challenger is None:
+            return
+        try:
+            t0 = time.perf_counter()
+            challenger_result = self.challenger.predict_one(request)
+            challenger_latency_ms = (time.perf_counter() - t0) * 1000
+        except Exception as exc:
+            log.warning("shadow_challenger_failed", error=str(exc))
+            with self._lock:
+                self._failed += 1
+            return
+
+        if challenger_latency_ms > self.challenger_budget_ms:
+            log.info(
+                "shadow_challenger_over_budget",
+                latency_ms=challenger_latency_ms,
+                budget_ms=self.challenger_budget_ms,
+            )
+            with self._lock:
+                self._skipped += 1
+            return
+
+        decision = ShadowDecision(
+            transaction_id=request.transaction_id,
+            champion_score=float(champion_score),
+            challenger_score=float(challenger_result.fraud_score),
+            score_delta=float(challenger_result.fraud_score - champion_score),
+            champion_label=champion_score >= self.threshold,
+            challenger_label=challenger_result.fraud_score >= self.threshold,
+            agreement=(champion_score >= self.threshold)
+            == (challenger_result.fraud_score >= self.threshold),
+            champion_model=self.champion.model_version,
+            challenger_model=self.challenger.model_version,
+            champion_latency_ms=champion_latency_ms,
+            challenger_latency_ms=challenger_latency_ms,
+        )
+        with self._lock:
+            self._records.append(decision)
+
+        # Hook into Prometheus -- lazy import to keep this module
+        # importable without the prometheus extras.
+        try:
+            from fraud_detection.monitoring.registry import monitoring_metrics
+
+            monitoring_metrics.record_shadow_decision(decision)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # introspection
+    # ------------------------------------------------------------------
+
+    def recent_decisions(self, limit: int = 100) -> list[ShadowDecision]:
+        with self._lock:
+            records = list(self._records)
+        return list(reversed(records[-limit:]))
+
+    def summary(self) -> ShadowSummary:
+        with self._lock:
+            records = list(self._records)
+            skipped = self._skipped
+            failed = self._failed
+        n_total = len(records)
+        if n_total == 0:
+            return ShadowSummary(
+                champion_model=self.champion.model_version,
+                challenger_model=self.challenger.model_version
+                if self.challenger is not None
+                else "",
+                challenger_skipped=skipped,
+                challenger_failed=failed,
+            )
+        agree = sum(1 for r in records if r.agreement)
+        deltas = [abs(r.score_delta) for r in records]
+        return ShadowSummary(
+            n_total=n_total,
+            n_agreement=agree,
+            n_disagreement=n_total - agree,
+            agreement_rate=agree / n_total,
+            mean_score_delta=sum(deltas) / n_total,
+            max_score_delta=max(deltas),
+            challenger_skipped=skipped,
+            challenger_failed=failed,
+            champion_model=self.champion.model_version,
+            challenger_model=self.challenger.model_version if self.challenger is not None else "",
+            window_start=records[0].timestamp,
+            window_end=records[-1].timestamp,
+        )
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+
+    def shutdown(self, *, wait: bool = False) -> None:
+        with contextlib.suppress(Exception):  # pragma: no cover -- defensive
+            self._executor.shutdown(wait=wait)
+
+
+__all__ = [
+    "ShadowDecision",
+    "ShadowDeployment",
+    "ShadowSummary",
+]

--- a/src/fraud_detection/monitoring/state.py
+++ b/src/fraud_detection/monitoring/state.py
@@ -1,0 +1,58 @@
+"""Module-level state for the monitoring layer.
+
+Both the FastAPI app and the offline CLI need somewhere to stash the
+*latest* drift report, the production performance tracker, and the alert
+evaluator. Splitting that into a tiny holder keeps the serving module's
+``AppState`` clean and lets the test-suite isolate state by importing the
+``reset_state`` helper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from fraud_detection.monitoring.alerts import AlertEvaluator, default_rules
+from fraud_detection.monitoring.performance import PerformanceTracker
+
+if TYPE_CHECKING:
+    from fraud_detection.monitoring.drift import DriftDetector, DriftReport
+    from fraud_detection.monitoring.shadow import ShadowDeployment
+
+
+@dataclass
+class MonitoringState:
+    """Live monitoring state shared across processes.
+
+    * ``performance`` -- the rolling labelled-prediction tracker.
+    * ``alerts`` -- the application-side alert evaluator.
+    * ``drift_detector`` -- the configured detector, ``None`` until a
+      reference distribution is registered.
+    * ``last_drift_report`` -- the most recent :class:`DriftReport`
+      computed via :meth:`recompute_drift` or the CLI.
+    """
+
+    performance: PerformanceTracker = field(default_factory=PerformanceTracker)
+    alerts: AlertEvaluator = field(default_factory=lambda: AlertEvaluator(default_rules()))
+    drift_detector: DriftDetector | None = None
+    last_drift_report: DriftReport | None = None
+    shadow: ShadowDeployment | None = None
+    reference_fraud_rate: float = 0.035  # IEEE-CIS training-time fraud rate
+
+
+_state: MonitoringState = MonitoringState()
+
+
+def get_state() -> MonitoringState:
+    """Return the process-wide monitoring state."""
+    return _state
+
+
+def reset_state() -> MonitoringState:
+    """Replace the process-wide state with a fresh instance (test helper)."""
+    global _state
+    _state = MonitoringState()
+    return _state
+
+
+__all__ = ["MonitoringState", "get_state", "reset_state"]

--- a/src/fraud_detection/serving/__init__.py
+++ b/src/fraud_detection/serving/__init__.py
@@ -1,56 +1,59 @@
 """FastAPI + Ray Serve serving stack (Phase 4).
 
-Public surface:
+Public surface (resolved lazily via PEP 562 ``__getattr__``):
 
 * :class:`FraudPredictor` -- core scoring path (Feast + cache + ensemble + SHAP).
 * :class:`EmbeddingCache` -- Redis-backed cache with in-memory fallback.
 * :class:`AlertBroadcaster` -- WebSocket fan-out for ``/ws/alerts``.
 * :class:`RequestTimingMiddleware` -- structured-log access logs + Prometheus metrics.
 * :func:`create_app` -- FastAPI factory.
-* :func:`build_deployment` -- optional Ray Serve wrapper.
 * Pydantic schemas for request/response/streaming.
+
+We resolve attributes lazily so that callers wanting only a single piece
+(say :data:`fraud_detection.serving.middleware.metrics`) don't have to
+pull in the whole app graph -- which would otherwise create a cycle with
+:mod:`fraud_detection.monitoring`.
 """
 
-from fraud_detection.serving.app import (
-    AlertBroadcaster,
-    AppState,
-    app,
-    create_app,
-)
-from fraud_detection.serving.middleware import RequestTimingMiddleware, metrics
-from fraud_detection.serving.predictor import FraudPredictor, load_predictor
-from fraud_detection.serving.redis_cache import EmbeddingCache
-from fraud_detection.serving.schemas import (
-    ALERT_THRESHOLD,
-    BatchPredictRequest,
-    BatchPredictResponse,
-    FeatureContribution,
-    FraudAlert,
-    FraudPrediction,
-    HealthStatus,
-    ModelInfoResponse,
-    TransactionRequest,
-    risk_level,
-)
+from __future__ import annotations
 
-__all__ = [
-    "ALERT_THRESHOLD",
-    "AlertBroadcaster",
-    "AppState",
-    "BatchPredictRequest",
-    "BatchPredictResponse",
-    "EmbeddingCache",
-    "FeatureContribution",
-    "FraudAlert",
-    "FraudPrediction",
-    "FraudPredictor",
-    "HealthStatus",
-    "ModelInfoResponse",
-    "RequestTimingMiddleware",
-    "TransactionRequest",
-    "app",
-    "create_app",
-    "load_predictor",
-    "metrics",
-    "risk_level",
-]
+from typing import Any
+
+_ATTR_MAP: dict[str, tuple[str, str]] = {
+    # name -> (submodule, attribute)
+    "AlertBroadcaster": ("fraud_detection.serving.app", "AlertBroadcaster"),
+    "AppState": ("fraud_detection.serving.app", "AppState"),
+    "app": ("fraud_detection.serving.app", "app"),
+    "create_app": ("fraud_detection.serving.app", "create_app"),
+    "RequestTimingMiddleware": ("fraud_detection.serving.middleware", "RequestTimingMiddleware"),
+    "metrics": ("fraud_detection.serving.middleware", "metrics"),
+    "FraudPredictor": ("fraud_detection.serving.predictor", "FraudPredictor"),
+    "load_predictor": ("fraud_detection.serving.predictor", "load_predictor"),
+    "EmbeddingCache": ("fraud_detection.serving.redis_cache", "EmbeddingCache"),
+    "ALERT_THRESHOLD": ("fraud_detection.serving.schemas", "ALERT_THRESHOLD"),
+    "BatchPredictRequest": ("fraud_detection.serving.schemas", "BatchPredictRequest"),
+    "BatchPredictResponse": ("fraud_detection.serving.schemas", "BatchPredictResponse"),
+    "FeatureContribution": ("fraud_detection.serving.schemas", "FeatureContribution"),
+    "FraudAlert": ("fraud_detection.serving.schemas", "FraudAlert"),
+    "FraudPrediction": ("fraud_detection.serving.schemas", "FraudPrediction"),
+    "HealthStatus": ("fraud_detection.serving.schemas", "HealthStatus"),
+    "ModelInfoResponse": ("fraud_detection.serving.schemas", "ModelInfoResponse"),
+    "TransactionRequest": ("fraud_detection.serving.schemas", "TransactionRequest"),
+    "risk_level": ("fraud_detection.serving.schemas", "risk_level"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    target = _ATTR_MAP.get(name)
+    if target is None:
+        raise AttributeError(f"module 'fraud_detection.serving' has no attribute {name!r}")
+    module_name, attr_name = target
+    import importlib
+
+    module = importlib.import_module(module_name)
+    value = getattr(module, attr_name)
+    globals()[name] = value  # cache so __getattr__ isn't called again
+    return value
+
+
+__all__ = sorted(_ATTR_MAP.keys())

--- a/src/fraud_detection/serving/app.py
+++ b/src/fraud_detection/serving/app.py
@@ -34,8 +34,10 @@ from typing import Any
 
 from fastapi import Body, FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 
+from fraud_detection.monitoring import MonitoringState, monitoring_metrics, report_to_html
+from fraud_detection.monitoring import get_state as get_monitoring_state
 from fraud_detection.serving.middleware import RequestTimingMiddleware, metrics
 from fraud_detection.serving.predictor import FraudPredictor, load_predictor
 from fraud_detection.serving.schemas import (
@@ -125,6 +127,11 @@ class AppState:
     recent_predictions: deque[FraudPrediction]
     recent_alerts: deque[FraudAlert]
 
+    # Phase 7 -- monitoring state holder; ``MonitoringState`` owns the
+    # production performance tracker, alert evaluator, and the last drift
+    # report. The same singleton is also reachable from the CLI.
+    monitoring: MonitoringState
+
     def __init__(self) -> None:
         self.predictor = None
         self.producer = None
@@ -136,6 +143,7 @@ class AppState:
         self.agent_compiled = None
         self.recent_predictions = deque(maxlen=200)
         self.recent_alerts = deque(maxlen=200)
+        self.monitoring = get_monitoring_state()
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +267,7 @@ async def lifespan(app: FastAPI):
 def create_app() -> FastAPI:
     app = FastAPI(
         title="Meshwatch Fraud Detection",
-        version="v0.6.0-dashboard",
+        version="v0.7.0-mlops",
         description="Real-time GNN+XGBoost fraud-detection inference API.",
         lifespan=lifespan,
     )
@@ -304,9 +312,18 @@ def _register_routes(app: FastAPI) -> None:
         s = _state(request)
         if s.predictor is None:
             raise HTTPException(status_code=503, detail="Model not loaded")
-        result = s.predictor.predict_one(payload)
+        # Route through the shadow lane when a challenger is attached -- the
+        # champion result is identical to a direct ``predict_one`` call,
+        # but the challenger scores in the background.
+        if s.monitoring.shadow is not None and s.monitoring.shadow.enabled:
+            result = s.monitoring.shadow.score(payload)
+        else:
+            result = s.predictor.predict_one(payload)
         metrics.predictions_total.labels(result.risk_level).inc()
         s.recent_predictions.append(result)
+        s.monitoring.performance.record_prediction(
+            result.transaction_id, result.fraud_score, timestamp=result.served_at
+        )
         if result.fraud_score >= s.predictor.threshold and s.producer is not None:
             alert = _to_alert(result, payload)
             s.producer.publish(alert)
@@ -333,6 +350,9 @@ def _register_routes(app: FastAPI) -> None:
         for r, tx in zip(results, payload.transactions, strict=True):
             metrics.predictions_total.labels(r.risk_level).inc()
             s.recent_predictions.append(r)
+            s.monitoring.performance.record_prediction(
+                r.transaction_id, r.fraud_score, timestamp=r.served_at
+            )
             if r.fraud_score >= s.predictor.threshold and s.producer is not None:
                 alert = _to_alert(r, tx)
                 s.producer.publish(alert)
@@ -410,6 +430,132 @@ def _register_routes(app: FastAPI) -> None:
     async def metrics_endpoint() -> Response:
         return Response(content=metrics.render(), media_type=metrics.content_type)
 
+    # ---- Monitoring (Phase 7) ----------------------------------------------
+
+    @app.get("/api/v1/monitoring/drift", tags=["monitoring"])
+    async def drift_endpoint(request: Request) -> dict[str, Any]:
+        s = _state(request)
+        report = s.monitoring.last_drift_report
+        if report is None:
+            return {
+                "status": "no_report",
+                "message": "No drift report has been computed yet. Run `make drift-report`.",
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        return report.to_dict()
+
+    @app.get("/api/v1/monitoring/drift.html", response_class=HTMLResponse, tags=["monitoring"])
+    async def drift_html_endpoint(request: Request) -> HTMLResponse:
+        s = _state(request)
+        report = s.monitoring.last_drift_report
+        if report is None:
+            return HTMLResponse(
+                "<!doctype html><meta charset='utf-8'><title>No drift report</title>"
+                "<body style='font-family:system-ui;padding:24px;'>"
+                "<h1>No drift report</h1>"
+                "<p>Run <code>make drift-report</code> to generate one.</p>"
+                "</body>",
+                status_code=200,
+            )
+        return HTMLResponse(report_to_html(report))
+
+    @app.get("/api/v1/monitoring/performance", tags=["monitoring"])
+    async def performance_endpoint(
+        request: Request, window_minutes: int | None = None
+    ) -> dict[str, Any]:
+        from datetime import timedelta as _td
+
+        s = _state(request)
+        window = _td(minutes=int(window_minutes)) if window_minutes else None
+        snap = s.monitoring.performance.snapshot(window=window)
+        monitoring_metrics.update_performance(snap)
+        return snap.to_dict()
+
+    @app.post("/api/v1/monitoring/label", tags=["monitoring"])
+    async def label_endpoint(
+        request: Request,
+        payload: dict[str, Any] = Body(...),  # noqa: B008
+    ) -> dict[str, Any]:
+        """Attach a ground-truth label to a previously-scored transaction.
+
+        Expected body: ``{"transaction_id": "<id>", "label": 0 | 1}``.
+        """
+        s = _state(request)
+        tx_id = payload.get("transaction_id")
+        label = payload.get("label")
+        if tx_id is None or label is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Request body must include 'transaction_id' and 'label'.",
+            )
+        try:
+            label_int = int(label)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400, detail="'label' must be coercible to int (0 or 1)."
+            ) from exc
+        if label_int not in (0, 1):
+            raise HTTPException(status_code=400, detail="'label' must be 0 or 1.")
+        found = s.monitoring.performance.record_label(tx_id, label_int)
+        # Refresh the Prometheus gauges so the dashboard surfaces the change.
+        snap = s.monitoring.performance.snapshot()
+        monitoring_metrics.update_performance(snap)
+        return {"transaction_id": tx_id, "label": label_int, "found": found}
+
+    @app.get("/api/v1/monitoring/alerts", tags=["monitoring"])
+    async def alerts_endpoint(request: Request) -> dict[str, Any]:
+        s = _state(request)
+        drift = s.monitoring.last_drift_report
+        snap = s.monitoring.performance.snapshot()
+        n_predictions = len(s.recent_predictions)
+        n_alerts = sum(
+            1 for p in s.recent_predictions if p.fraud_score >= s.monitoring.performance.threshold
+        )
+        production_fraud_rate = n_alerts / n_predictions if n_predictions > 0 else 0.0
+        shadow_summary = s.monitoring.shadow.summary() if s.monitoring.shadow is not None else None
+        ctx: dict[str, Any] = {
+            "model_loaded": s.predictor is not None,
+            "drift_overall": float(drift.overall_psi) if drift is not None else 0.0,
+            "drift_severe": int(drift.n_severe) if drift is not None else 0,
+            "performance": snap,
+            "production_fraud_rate": production_fraud_rate,
+            "reference_fraud_rate": s.monitoring.reference_fraud_rate,
+            "shadow": shadow_summary,
+            "latency_p95": 0.0,
+            "error_rate": 0.0,
+        }
+        fired = s.monitoring.alerts.evaluate(ctx)
+        return {
+            "n_active": len(fired),
+            "alerts": [a.to_dict() for a in fired],
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    @app.get("/api/v1/monitoring/shadow", tags=["monitoring"])
+    async def shadow_summary_endpoint(request: Request) -> dict[str, Any]:
+        s = _state(request)
+        if s.monitoring.shadow is None:
+            return {
+                "status": "disabled",
+                "message": "Shadow deployment not configured.",
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        summary = s.monitoring.shadow.summary()
+        monitoring_metrics.update_shadow_summary(summary)
+        return summary.to_dict()
+
+    @app.get("/api/v1/monitoring/shadow/recent", tags=["monitoring"])
+    async def shadow_recent_endpoint(request: Request, limit: int = 50) -> dict[str, Any]:
+        s = _state(request)
+        if s.monitoring.shadow is None:
+            return {"status": "disabled", "decisions": []}
+        decisions = s.monitoring.shadow.recent_decisions(limit=max(1, min(int(limit), 500)))
+        return {
+            "n": len(decisions),
+            "decisions": [d.to_dict() for d in decisions],
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        }
+
     # ---- Investigate (Phase 5) ----------------------------------------------
 
     @app.post("/api/v1/investigate", tags=["investigate"])
@@ -446,7 +592,27 @@ def _register_routes(app: FastAPI) -> None:
             request=request_payload,
             alert_id=payload.alert_id,
         )
-        report = investigate(state, deps=s.agent_deps, compiled=s.agent_compiled)
+        t_agent = time.perf_counter()
+        agent_status = "ok"
+        try:
+            report = investigate(state, deps=s.agent_deps, compiled=s.agent_compiled)
+        except Exception:
+            agent_status = "error"
+            monitoring_metrics.record_agent_run(
+                risk_level=str(prediction.risk_level),
+                latency_seconds=time.perf_counter() - t_agent,
+                status=agent_status,
+            )
+            raise
+        tool_calls = [
+            (str(c.get("name", "?")), str(c.get("status", "ok"))) for c in report.tool_calls
+        ]
+        monitoring_metrics.record_agent_run(
+            risk_level=str(report.risk_level),
+            latency_seconds=time.perf_counter() - t_agent,
+            status=agent_status,
+            tool_calls=tool_calls,
+        )
         metrics.predictions_total.labels(report.risk_level).inc()
         return report.model_dump(mode="json")
 

--- a/tests/unit/test_monitor_script.py
+++ b/tests/unit/test_monitor_script.py
@@ -1,0 +1,140 @@
+"""Unit tests for scripts/monitor.py (Phase 7 CLI)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from click.testing import CliRunner
+from scripts.monitor import main as monitor_cli
+
+
+def _write_parquet(path: Path, df: pd.DataFrame) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(path)
+
+
+def _make_dataframes():
+    rng = np.random.default_rng(99)
+    ref = pd.DataFrame(
+        {
+            "amount": rng.normal(loc=0, scale=1, size=300),
+            "country": rng.choice(["US", "GB", "CA"], size=300),
+        }
+    )
+    cur = pd.DataFrame(
+        {
+            "amount": rng.normal(loc=4, scale=1, size=300),  # severe drift
+            "country": rng.choice(["US", "GB", "CA"], size=300),
+        }
+    )
+    return ref, cur
+
+
+def test_monitor_cli_writes_json_and_html(tmp_path):
+    ref_path = tmp_path / "ref.parquet"
+    cur_path = tmp_path / "cur.parquet"
+    out_dir = tmp_path / "out"
+    ref, cur = _make_dataframes()
+    _write_parquet(ref_path, ref)
+    _write_parquet(cur_path, cur)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        monitor_cli,
+        [
+            "--reference",
+            str(ref_path),
+            "--current",
+            str(cur_path),
+            "--output-dir",
+            str(out_dir),
+            "--top-k",
+            "5",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (out_dir / "drift.json").exists()
+    assert (out_dir / "drift.html").exists()
+
+    payload = json.loads((out_dir / "drift.json").read_text())
+    assert payload["n_features"] == 2
+    # Severe shift on `amount` -> overall severity is "severe".
+    assert payload["severity"] == "severe"
+
+
+def test_monitor_cli_accepts_csv_input(tmp_path):
+    ref_path = tmp_path / "ref.csv"
+    cur_path = tmp_path / "cur.csv"
+    out_dir = tmp_path / "out"
+    ref, cur = _make_dataframes()
+    ref.to_csv(ref_path, index=False)
+    cur.to_csv(cur_path, index=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        monitor_cli,
+        [
+            "--reference",
+            str(ref_path),
+            "--current",
+            str(cur_path),
+            "--output-dir",
+            str(out_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (out_dir / "drift.json").exists()
+
+
+def test_monitor_cli_respects_feature_subset(tmp_path):
+    ref_path = tmp_path / "ref.parquet"
+    cur_path = tmp_path / "cur.parquet"
+    out_dir = tmp_path / "out"
+    ref, cur = _make_dataframes()
+    _write_parquet(ref_path, ref)
+    _write_parquet(cur_path, cur)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        monitor_cli,
+        [
+            "--reference",
+            str(ref_path),
+            "--current",
+            str(cur_path),
+            "--output-dir",
+            str(out_dir),
+            "--features",
+            "amount",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads((out_dir / "drift.json").read_text())
+    feats = {f["feature"] for f in payload["features"]}
+    assert feats == {"amount"}
+
+
+def test_monitor_cli_exits_with_two_when_no_overlap(tmp_path):
+    ref_path = tmp_path / "ref.parquet"
+    cur_path = tmp_path / "cur.parquet"
+    out_dir = tmp_path / "out"
+    _write_parquet(ref_path, pd.DataFrame({"only_ref": [1, 2, 3]}))
+    _write_parquet(cur_path, pd.DataFrame({"only_cur": [4, 5, 6]}))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        monitor_cli,
+        [
+            "--reference",
+            str(ref_path),
+            "--current",
+            str(cur_path),
+            "--output-dir",
+            str(out_dir),
+        ],
+    )
+    assert result.exit_code == 2
+    assert "No overlapping features" in result.output

--- a/tests/unit/test_monitoring_alerts.py
+++ b/tests/unit/test_monitoring_alerts.py
@@ -1,0 +1,209 @@
+"""Unit tests for the application-side alert evaluator (Phase 7)."""
+
+from __future__ import annotations
+
+import pytest
+
+from fraud_detection.monitoring.alerts import (
+    Alert,
+    AlertEvaluator,
+    AlertRule,
+    default_rules,
+)
+from fraud_detection.monitoring.performance import PerformanceSnapshot
+
+
+class TestAlertRule:
+    def test_rule_predicate_is_called(self):
+        rule = AlertRule(
+            name="t",
+            severity="info",
+            description="",
+            predicate=lambda ctx: ctx["x"] > 1,
+            reason=lambda ctx: f"x={ctx['x']}",
+        )
+        evaluator = AlertEvaluator([rule])
+        active = evaluator.evaluate({"x": 2})
+        assert len(active) == 1
+        assert isinstance(active[0], Alert)
+        assert active[0].name == "t"
+        assert active[0].reason == "x=2"
+
+    def test_rule_does_not_fire_when_predicate_false(self):
+        rule = AlertRule(
+            name="t",
+            severity="info",
+            description="",
+            predicate=lambda ctx: ctx["x"] > 10,
+        )
+        evaluator = AlertEvaluator([rule])
+        assert evaluator.evaluate({"x": 1}) == []
+
+    def test_predicate_exception_yields_warning_alert(self):
+        def _bad_predicate(_ctx: dict) -> bool:
+            raise RuntimeError("boom")
+
+        rule = AlertRule(
+            name="t",
+            severity="critical",
+            description="",
+            predicate=_bad_predicate,
+        )
+        evaluator = AlertEvaluator([rule])
+        active = evaluator.evaluate({})
+        assert len(active) == 1
+        assert active[0].severity == "warning"
+        assert "Rule evaluation failed" in active[0].reason
+
+
+class TestDefaultRules:
+    def test_default_rules_fire_in_isolation(self):
+        rules = default_rules(
+            psi_alert=0.25,
+            latency_p95_warn=0.05,  # 50ms plan budget
+            error_rate_warn=0.05,
+            performance_recall_warn=0.55,
+            psi_severe_features=10,
+            performance_auprc_warn=0.60,
+            fraud_rate_spike=0.10,
+        )
+        evaluator = AlertEvaluator(rules)
+
+        # 1) Model not loaded
+        fired = {a.name for a in evaluator.evaluate({"model_loaded": False})}
+        assert "ModelNotLoaded" in fired
+
+        # 2) Drift severe (overall PSI >= threshold)
+        fired = {
+            a.name
+            for a in evaluator.evaluate(
+                {"model_loaded": True, "drift_overall": 0.30, "drift_severe": 3}
+            )
+        }
+        assert "DataDriftSevere" in fired
+
+        # 3) Many features drifting (plan threshold = >10)
+        fired = {a.name for a in evaluator.evaluate({"model_loaded": True, "drift_severe": 15})}
+        assert "DataDrift" in fired
+
+        # 4) Performance degraded (recall)
+        snap = PerformanceSnapshot(n_labelled=100, recall=0.40, precision=0.9, f1=0.5)
+        fired = {a.name for a in evaluator.evaluate({"model_loaded": True, "performance": snap})}
+        assert "ModelPerformanceDegraded" in fired
+
+        # 5) Model degraded (AUPRC < 0.60 -- plan threshold)
+        snap = PerformanceSnapshot(
+            n_labelled=100, recall=0.9, precision=0.9, f1=0.9, auprc=0.45, auroc=0.88
+        )
+        fired = {a.name for a in evaluator.evaluate({"model_loaded": True, "performance": snap})}
+        assert "ModelDegradation" in fired
+
+        # 6) Fraud rate spike (plan threshold = 10%)
+        fired = {
+            a.name
+            for a in evaluator.evaluate(
+                {
+                    "model_loaded": True,
+                    "production_fraud_rate": 0.18,
+                    "reference_fraud_rate": 0.035,
+                }
+            )
+        }
+        assert "FraudRateSpike" in fired
+
+        # 7) Latency (50ms budget)
+        fired = {a.name for a in evaluator.evaluate({"model_loaded": True, "latency_p95": 0.1})}
+        assert "HighLatency" in fired
+
+        # 8) Error rate
+        fired = {a.name for a in evaluator.evaluate({"model_loaded": True, "error_rate": 0.1})}
+        assert "HighErrorRate" in fired
+
+        # 9) Shadow agreement
+        shadow_summary = {"n_total": 100, "agreement_rate": 0.75}
+        fired = {
+            a.name for a in evaluator.evaluate({"model_loaded": True, "shadow": shadow_summary})
+        }
+        assert "ShadowChallengerDisagreement" in fired
+
+    def test_drift_severe_includes_overall_psi_in_reason(self):
+        rules = default_rules()
+        evaluator = AlertEvaluator(rules)
+        active = evaluator.evaluate(
+            {"model_loaded": True, "drift_overall": 0.33, "drift_severe": 2}
+        )
+        rule = next(a for a in active if a.name == "DataDriftSevere")
+        assert "0.330" in rule.reason
+        assert "2" in rule.reason
+
+    def test_no_rules_fire_in_a_healthy_context(self):
+        rules = default_rules()
+        evaluator = AlertEvaluator(rules)
+        snap = PerformanceSnapshot(
+            n_labelled=100,
+            recall=0.95,
+            precision=0.95,
+            f1=0.95,
+            auprc=0.85,
+            auroc=0.95,
+        )
+        ctx = {
+            "model_loaded": True,
+            "drift_overall": 0.05,
+            "drift_severe": 0,
+            "performance": snap,
+            "production_fraud_rate": 0.03,
+            "reference_fraud_rate": 0.035,
+            "shadow": {"n_total": 100, "agreement_rate": 0.99},
+            "latency_p95": 0.02,
+            "error_rate": 0.001,
+        }
+        assert evaluator.evaluate(ctx) == []
+
+    def test_fraud_rate_spike_reason_includes_baseline(self):
+        rules = default_rules(fraud_rate_spike=0.10)
+        evaluator = AlertEvaluator(rules)
+        active = evaluator.evaluate(
+            {
+                "model_loaded": True,
+                "production_fraud_rate": 0.22,
+                "reference_fraud_rate": 0.035,
+            }
+        )
+        rule = next(a for a in active if a.name == "FraudRateSpike")
+        assert "22.00%" in rule.reason
+        assert "3.50%" in rule.reason
+
+    def test_alert_to_dict_serialises_datetime(self):
+        alert = Alert(name="t", severity="info", description="", reason="r")
+        d = alert.to_dict()
+        assert isinstance(d["fired_at"], str)
+        # ISO format check
+        assert "T" in d["fired_at"]
+
+
+class TestRecallRuleFallbacks:
+    def test_recall_rule_skips_unlabelled_snapshot(self):
+        rules = default_rules(performance_recall_warn=0.99)  # very strict
+        evaluator = AlertEvaluator(rules)
+        # Zero labels means recall is unknown -- the rule should not fire.
+        snap = PerformanceSnapshot(n_labelled=0, recall=0.0)
+        active = {a.name for a in evaluator.evaluate({"model_loaded": True, "performance": snap})}
+        assert "ModelPerformanceDegraded" not in active
+
+    def test_recall_rule_handles_dict_snapshot(self):
+        # The evaluator should accept either the dataclass or a dict so that
+        # serialised payloads from the API can flow through unchanged.
+        rules = default_rules(performance_recall_warn=0.6)
+        evaluator = AlertEvaluator(rules)
+        ctx = {"model_loaded": True, "performance": {"n_labelled": 50, "recall": 0.3}}
+        fired = {a.name for a in evaluator.evaluate(ctx)}
+        assert "ModelPerformanceDegraded" in fired
+
+    @pytest.mark.parametrize("missing_key", ["drift_overall", "latency_p95", "error_rate"])
+    def test_default_rules_handle_missing_context_keys(self, missing_key):
+        rules = default_rules()
+        evaluator = AlertEvaluator(rules)
+        ctx = {"model_loaded": True}
+        # Should not raise even though most context keys are missing.
+        assert evaluator.evaluate(ctx) == []

--- a/tests/unit/test_monitoring_drift.py
+++ b/tests/unit/test_monitoring_drift.py
@@ -1,0 +1,252 @@
+"""Unit tests for the drift detection module (Phase 7)."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from fraud_detection.monitoring.drift import (
+    DriftDetector,
+    DriftDetectorConfig,
+    categorical_psi,
+    chi_square,
+    js_divergence,
+    ks_test,
+    label_drift,
+    population_stability_index,
+    prediction_distribution_drift,
+)
+
+_RNG = np.random.default_rng(42)
+
+
+# ---------------------------------------------------------------------------
+# Pure stats helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPopulationStabilityIndex:
+    def test_identical_distributions_yield_near_zero(self):
+        ref = _RNG.normal(size=2000)
+        psi = population_stability_index(ref, ref)
+        assert psi == pytest.approx(0.0, abs=1e-9)
+
+    def test_resampled_same_distribution_yields_low_psi(self):
+        ref = _RNG.normal(size=2000)
+        cur = _RNG.normal(size=2000)
+        psi = population_stability_index(ref, cur)
+        # Same generating distribution should be deep below the warn threshold.
+        assert psi < 0.05
+
+    def test_mean_shift_triggers_severe_psi(self):
+        ref = _RNG.normal(loc=0, size=2000)
+        cur = _RNG.normal(loc=2, size=2000)  # 2-sigma shift
+        psi = population_stability_index(ref, cur)
+        assert psi > 0.25  # severe threshold
+
+    def test_psi_handles_empty_inputs(self):
+        assert population_stability_index([], [1, 2, 3]) == 0.0
+        assert population_stability_index([1, 2, 3], []) == 0.0
+
+    def test_psi_handles_constant_reference(self):
+        # Should not raise and should produce a finite number.
+        psi = population_stability_index(np.zeros(100), _RNG.normal(size=100))
+        assert math.isfinite(psi)
+
+
+class TestCategoricalPSI:
+    def test_identical_categorical_distributions_psi_zero(self):
+        labels = ["a", "b", "c"] * 100
+        assert categorical_psi(labels, labels) == pytest.approx(0.0, abs=1e-9)
+
+    def test_disappearing_category_triggers_drift(self):
+        ref = ["a"] * 500 + ["b"] * 500
+        cur = ["a"] * 1000  # category "b" disappeared
+        psi = categorical_psi(ref, cur)
+        assert psi > 0.25
+
+
+class TestKSTest:
+    def test_same_distribution_yields_small_statistic(self):
+        ref = _RNG.normal(size=2000)
+        cur = _RNG.normal(size=2000)
+        stat, _p = ks_test(ref, cur)
+        assert stat < 0.1
+
+    def test_shifted_distribution_yields_large_statistic(self):
+        ref = _RNG.normal(loc=0, size=2000)
+        cur = _RNG.normal(loc=3, size=2000)
+        stat, _p = ks_test(ref, cur)
+        assert stat > 0.5
+
+
+class TestJSDivergence:
+    def test_identical_distributions_yield_zero(self):
+        ref = _RNG.normal(size=2000)
+        assert js_divergence(ref, ref) == pytest.approx(0.0, abs=1e-9)
+
+    def test_mean_shift_increases_jsd(self):
+        ref = _RNG.normal(loc=0, size=2000)
+        cur = _RNG.normal(loc=3, size=2000)
+        jsd = js_divergence(ref, cur)
+        assert jsd > 0.1
+
+
+class TestChiSquare:
+    def test_returns_zero_when_distributions_match(self):
+        labels = ["a", "b", "c", "d"] * 250
+        stat, _p = chi_square(labels, labels)
+        assert stat < 1e-6
+
+    def test_returns_large_statistic_when_categories_shift(self):
+        ref = ["a"] * 1000
+        cur = ["b"] * 1000
+        stat, _p = chi_square(ref, cur)
+        assert stat > 100
+
+
+# ---------------------------------------------------------------------------
+# DriftDetector integration
+# ---------------------------------------------------------------------------
+
+
+class TestDriftDetector:
+    def _reference(self) -> dict:
+        return {
+            "amount": _RNG.normal(loc=50, scale=20, size=2000).tolist(),
+            "product": _RNG.choice(["W", "C", "H"], size=2000, p=[0.7, 0.2, 0.1]).tolist(),
+            "country": _RNG.choice(["US", "GB", "CA"], size=2000).tolist(),
+        }
+
+    def test_infers_kind_per_feature(self):
+        det = DriftDetector(self._reference())
+        assert "amount" in det.numeric_features
+        assert "product" in det.categorical_features
+        assert "country" in det.categorical_features
+        assert det.n_reference == 2000
+
+    def test_reports_no_drift_for_matching_current(self):
+        ref = self._reference()
+        det = DriftDetector(ref)
+        report = det.detect(ref)
+        # PSI(ref, ref) is bounded by binning noise; ensure overall stays
+        # well below the warn threshold.
+        assert report.overall_psi < 0.05
+        assert report.severity == "none"
+        assert report.n_severe == 0
+        # Every feature gets a row.
+        names = {f.feature for f in report.features}
+        assert names == {"amount", "product", "country"}
+
+    def test_detects_numeric_drift(self):
+        ref = self._reference()
+        cur = {
+            "amount": _RNG.normal(loc=500, scale=20, size=2000).tolist(),  # 22 sigma shift
+            "product": ref["product"],
+            "country": ref["country"],
+        }
+        det = DriftDetector(ref)
+        report = det.detect(cur)
+        amount = next(f for f in report.features if f.feature == "amount")
+        assert amount.severity == "severe"
+        assert amount.mean_shift is not None and amount.mean_shift > 100
+        assert report.overall_psi >= 0.25
+        assert report.severity == "severe"
+
+    def test_detects_categorical_drift(self):
+        ref = self._reference()
+        cur = {
+            "amount": ref["amount"],
+            "product": ["W"] * 2000,  # product distribution collapsed
+            "country": ref["country"],
+        }
+        det = DriftDetector(ref)
+        report = det.detect(cur)
+        product = next(f for f in report.features if f.feature == "product")
+        assert product.kind == "categorical"
+        assert product.severity in {"moderate", "severe"}
+
+    def test_skips_features_missing_from_current(self):
+        ref = self._reference()
+        cur = {"amount": ref["amount"]}  # only one feature
+        report = DriftDetector(ref).detect(cur)
+        assert len(report.features) == 1
+        assert report.features[0].feature == "amount"
+
+    def test_explicit_feature_kinds_override_inference(self):
+        ref = {"binary_int": [0, 1] * 1000}
+        # Force categorical treatment even though the values are numeric.
+        det = DriftDetector(ref, categorical_features=["binary_int"])
+        assert "binary_int" in det.categorical_features
+
+    def test_top_k_orders_features_by_psi(self):
+        ref = self._reference()
+        cur = {
+            "amount": _RNG.normal(loc=500, scale=20, size=2000).tolist(),  # huge drift
+            "product": ref["product"],  # no drift
+            "country": ref["country"],  # no drift
+        }
+        det = DriftDetector(ref)
+        report = det.detect(cur)
+        top = report.top(2)
+        assert len(top) == 2
+        assert top[0].feature == "amount"
+
+    def test_severity_thresholds_via_config(self):
+        ref = self._reference()
+        cur = {
+            "amount": _RNG.normal(loc=55, scale=20, size=2000).tolist(),  # mild drift
+            "product": ref["product"],
+            "country": ref["country"],
+        }
+        # With permissive thresholds the same mild shift looks fine.
+        permissive = DriftDetector(ref, config=DriftDetectorConfig(psi_warn=1.0, psi_alert=2.0))
+        assert permissive.detect(cur).severity == "none"
+
+        # With aggressive thresholds (warn at any non-zero PSI), it becomes moderate.
+        strict = DriftDetector(ref, config=DriftDetectorConfig(psi_warn=1e-9, psi_alert=10.0))
+        assert strict.detect(cur).severity == "moderate"
+
+    def test_to_dict_round_trip(self):
+        det = DriftDetector(self._reference())
+        report = det.detect(self._reference())
+        d = report.to_dict()
+        assert d["n_features"] == 3
+        assert "features" in d and isinstance(d["features"], list)
+        assert d["severity"] in {"none", "moderate", "severe"}
+
+
+class TestLabelDrift:
+    def test_label_drift_reports_zero_for_matching_rates(self):
+        labels = [1] * 35 + [0] * 965  # 3.5% positive
+        result = label_drift(labels, reference_rate=0.035)
+        assert result["n"] == 1000
+        assert result["production_rate"] == pytest.approx(0.035, abs=1e-6)
+        assert result["absolute_drift"] == pytest.approx(0.0, abs=1e-6)
+
+    def test_label_drift_detects_spike(self):
+        labels = [1] * 200 + [0] * 800  # 20%
+        result = label_drift(labels, reference_rate=0.035)
+        assert result["production_rate"] == pytest.approx(0.20, abs=1e-6)
+        assert result["absolute_drift"] == pytest.approx(0.165, abs=1e-6)
+
+    def test_label_drift_handles_empty(self):
+        result = label_drift([], reference_rate=0.05)
+        assert result["n"] == 0
+        assert result["production_rate"] == 0.0
+        assert result["absolute_drift"] == 0.0
+
+
+class TestPredictionDistributionDrift:
+    def test_zero_psi_on_identical_distributions(self):
+        scores = _RNG.uniform(0, 1, size=1000)
+        assert prediction_distribution_drift(scores, scores) == pytest.approx(0.0, abs=1e-9)
+
+    def test_severe_psi_when_distribution_shifts(self):
+        ref = _RNG.uniform(0, 0.5, size=1000)
+        cur = _RNG.uniform(0.5, 1.0, size=1000)
+        psi = prediction_distribution_drift(cur, ref)
+        # Shifting from the bottom half to the top half is a severe move.
+        assert psi >= 0.25

--- a/tests/unit/test_monitoring_endpoint.py
+++ b/tests/unit/test_monitoring_endpoint.py
@@ -1,0 +1,227 @@
+"""Integration tests for the Phase 7 monitoring endpoints."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from fraud_detection.monitoring import (
+    DriftDetector,
+    DriftReport,
+    PerformanceTracker,
+    reset_state,
+)
+from fraud_detection.serving.app import AppState, create_app
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("FRAUD_ENSEMBLE_DIR", "/nonexistent/path/skip-load")
+    monkeypatch.setenv("FRAUD_AGENT_DISABLED", "true")
+    reset_state()  # isolate the monitoring singleton between tests
+    app = create_app()
+    with TestClient(app) as c:
+        # Give the app a fresh, empty tracker so we can record clean states.
+        state: AppState = app.state.fraud_app
+        state.monitoring.performance = PerformanceTracker(threshold=0.5)
+        yield c, state
+
+
+def _seed_drift_report(state: AppState) -> DriftReport:
+    rng = np.random.default_rng(3)
+    ref = {
+        "amount": rng.normal(loc=0, scale=1, size=500).tolist(),
+        "country": rng.choice(["US", "GB"], size=500).tolist(),
+    }
+    cur = {
+        "amount": rng.normal(loc=4, scale=1, size=500).tolist(),
+        "country": rng.choice(["US", "GB"], size=500).tolist(),
+    }
+    report = DriftDetector(ref).detect(cur)
+    state.monitoring.last_drift_report = report
+    state.monitoring.drift_detector = DriftDetector(ref)
+    return report
+
+
+class TestDriftEndpoints:
+    def test_drift_endpoint_returns_no_report_initially(self, client):
+        c, _state = client
+        resp = c.get("/api/v1/monitoring/drift")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "no_report"
+
+    def test_drift_endpoint_returns_report_when_seeded(self, client):
+        c, state = client
+        seeded = _seed_drift_report(state)
+        resp = c.get("/api/v1/monitoring/drift")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["n_features"] == seeded.n_features
+        assert body["severity"] in {"none", "moderate", "severe"}
+
+    def test_drift_html_endpoint_returns_html(self, client):
+        c, state = client
+        _seed_drift_report(state)
+        resp = c.get("/api/v1/monitoring/drift.html")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        assert resp.text.startswith("<!doctype html>")
+        assert "Overall PSI" in resp.text
+
+    def test_drift_html_endpoint_returns_placeholder_when_empty(self, client):
+        c, _state = client
+        resp = c.get("/api/v1/monitoring/drift.html")
+        assert resp.status_code == 200
+        assert "No drift report" in resp.text
+
+
+class TestPerformanceEndpoint:
+    def test_performance_endpoint_returns_empty_snapshot(self, client):
+        c, _state = client
+        resp = c.get("/api/v1/monitoring/performance")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["n_labelled"] == 0
+        assert body["n_total"] == 0
+
+    def test_performance_endpoint_reports_metrics_after_labels(self, client):
+        c, state = client
+        # Manually populate the tracker.
+        state.monitoring.performance.record_prediction("tx_1", 0.9, label=1)
+        state.monitoring.performance.record_prediction("tx_2", 0.2, label=0)
+        state.monitoring.performance.record_prediction("tx_3", 0.6, label=1)
+        resp = c.get("/api/v1/monitoring/performance")
+        body = resp.json()
+        assert body["n_labelled"] == 3
+        assert body["precision"] > 0
+        assert body["recall"] > 0
+
+
+class TestLabelEndpoint:
+    def test_label_endpoint_attaches_label(self, client):
+        c, state = client
+        state.monitoring.performance.record_prediction("tx_lbl", 0.9)
+        resp = c.post(
+            "/api/v1/monitoring/label",
+            json={"transaction_id": "tx_lbl", "label": 1},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["found"] is True
+        assert body["label"] == 1
+        assert state.monitoring.performance.n_labelled == 1
+
+    def test_label_endpoint_400_when_missing_fields(self, client):
+        c, _state = client
+        resp = c.post("/api/v1/monitoring/label", json={"transaction_id": "x"})
+        assert resp.status_code == 400
+
+    def test_label_endpoint_rejects_invalid_label(self, client):
+        c, _state = client
+        resp = c.post(
+            "/api/v1/monitoring/label",
+            json={"transaction_id": "x", "label": 2},
+        )
+        assert resp.status_code == 400
+
+    def test_label_endpoint_handles_unknown_transaction(self, client):
+        c, _state = client
+        resp = c.post(
+            "/api/v1/monitoring/label",
+            json={"transaction_id": "never_existed", "label": 1},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["found"] is False
+
+
+class TestAlertsEndpoint:
+    def test_alerts_endpoint_returns_empty_on_healthy_state(self, client):
+        c, state = client
+        state.predictor = object()  # type: ignore[assignment] -- truthy stand-in
+        resp = c.get("/api/v1/monitoring/alerts")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["n_active"] == 0
+        assert body["alerts"] == []
+
+    def test_alerts_endpoint_fires_on_model_unloaded(self, client):
+        c, state = client
+        state.predictor = None  # type: ignore[assignment]
+        resp = c.get("/api/v1/monitoring/alerts")
+        body = resp.json()
+        names = {a["name"] for a in body["alerts"]}
+        assert "ModelNotLoaded" in names
+
+    def test_alerts_endpoint_includes_drift_alert_when_severe(self, client):
+        c, state = client
+        state.predictor = object()  # type: ignore[assignment]
+        _seed_drift_report(state)  # this builds a severe-drift report
+        resp = c.get("/api/v1/monitoring/alerts")
+        body = resp.json()
+        names = {a["name"] for a in body["alerts"]}
+        assert "DataDriftSevere" in names
+
+
+class TestPrometheusExposition:
+    def test_metrics_endpoint_includes_meshwatch_namespace(self, client):
+        c, _state = client
+        resp = c.get("/api/v1/metrics")
+        assert resp.status_code == 200
+        # Without prometheus_client the endpoint returns a no-op placeholder;
+        # with it installed, we get the meshwatch_* namespace.
+        body = resp.text
+        assert "meshwatch_http_requests_total" in body or "prometheus_client not installed" in body
+
+
+class TestShadowEndpoints:
+    def test_shadow_summary_disabled_when_not_attached(self, client):
+        c, _state = client
+        resp = c.get("/api/v1/monitoring/shadow")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "disabled"
+
+    def test_shadow_summary_returns_aggregates_when_attached(self, client):
+        from fraud_detection.monitoring import ShadowDeployment
+
+        c, state = client
+
+        class _Pred:
+            model_version = "test-v1"
+            threshold = 0.7
+
+            def predict_one(self, req):
+                from fraud_detection.serving.schemas import FraudPrediction, risk_level
+
+                score = min(0.99, req.transaction_amt / 1000.0)
+                return FraudPrediction(
+                    transaction_id=req.transaction_id,
+                    fraud_probability=score,
+                    fraud_score=score,
+                    risk_level=risk_level(score),
+                    is_fraud_predicted=score >= self.threshold,
+                    threshold=self.threshold,
+                    top_features=[],
+                    latency_ms={"total_ms": 0.1},
+                    model_version=self.model_version,
+                )
+
+        deployment = ShadowDeployment(champion=_Pred(), challenger=_Pred(), max_records=10)  # type: ignore[arg-type]
+        try:
+            state.monitoring.shadow = deployment
+            resp = c.get("/api/v1/monitoring/shadow")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert "champion_model" in body
+            assert body["champion_model"] == "test-v1"
+
+            resp = c.get("/api/v1/monitoring/shadow/recent?limit=5")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["n"] == 0
+        finally:
+            deployment.shutdown(wait=True)
+            state.monitoring.shadow = None

--- a/tests/unit/test_monitoring_performance.py
+++ b/tests/unit/test_monitoring_performance.py
@@ -1,0 +1,148 @@
+"""Unit tests for the production performance tracker (Phase 7)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+import pytest
+
+from fraud_detection.monitoring.performance import (
+    PerformanceTracker,
+    auprc,
+    auroc,
+)
+
+_RNG = np.random.default_rng(42)
+
+
+class TestAUCMetrics:
+    def test_auroc_perfect_separation(self):
+        y_true = [0, 0, 0, 1, 1, 1]
+        y_score = [0.1, 0.2, 0.3, 0.7, 0.8, 0.9]
+        assert auroc(y_true, y_score) == pytest.approx(1.0, abs=1e-9)
+
+    def test_auroc_no_signal(self):
+        y_true = [0, 0, 1, 1] * 100
+        y_score = [0.5] * 400
+        # AUROC under no signal is 0.5; with random tie-breaking the value
+        # can fluctuate but should stay close to 0.5.
+        assert 0.4 < auroc(y_true, y_score) < 0.6
+
+    def test_auroc_handles_single_class(self):
+        # All labels the same -- AUROC undefined; expect NaN.
+        result = auroc([0, 0, 0], [0.1, 0.2, 0.3])
+        assert result != result  # NaN
+
+    def test_auprc_perfect_separation(self):
+        y_true = [0, 0, 0, 1, 1, 1]
+        y_score = [0.1, 0.2, 0.3, 0.7, 0.8, 0.9]
+        assert auprc(y_true, y_score) == pytest.approx(1.0, abs=1e-9)
+
+    def test_auprc_handles_no_positives(self):
+        result = auprc([0, 0, 0], [0.1, 0.2, 0.3])
+        assert result != result  # NaN
+
+
+class TestPerformanceTracker:
+    def test_records_predictions_without_labels(self):
+        t = PerformanceTracker(max_records=10)
+        for i in range(5):
+            t.record_prediction(transaction_id=f"tx_{i}", score=0.5)
+        assert t.n_records == 5
+        assert t.n_labelled == 0
+
+    def test_label_attaches_to_existing_record(self):
+        t = PerformanceTracker()
+        t.record_prediction("tx_1", 0.9)
+        assert t.record_label("tx_1", 1) is True
+        assert t.n_labelled == 1
+
+    def test_label_returns_false_when_record_missing(self):
+        t = PerformanceTracker()
+        assert t.record_label("unknown_tx", 1) is False
+
+    def test_ring_buffer_evicts_oldest(self):
+        t = PerformanceTracker(max_records=3)
+        for i in range(5):
+            t.record_prediction(f"tx_{i}", 0.5)
+        assert t.n_records == 3
+
+    def test_reset_clears_buffer(self):
+        t = PerformanceTracker()
+        t.record_prediction("tx_1", 0.5)
+        t.reset()
+        assert t.n_records == 0
+
+    def test_snapshot_with_no_labels_returns_empty(self):
+        t = PerformanceTracker()
+        for i in range(5):
+            t.record_prediction(f"tx_{i}", 0.5)
+        snap = t.snapshot()
+        assert snap.n_total == 5
+        assert snap.n_labelled == 0
+        assert snap.precision == 0.0
+        assert snap.recall == 0.0
+
+    def test_snapshot_computes_classification_metrics(self):
+        t = PerformanceTracker(threshold=0.5)
+        # TP: 2, FP: 1, FN: 1, TN: 2 -- precision 2/3, recall 2/3
+        t.record_prediction("a", 0.9, label=1)
+        t.record_prediction("b", 0.8, label=1)
+        t.record_prediction("c", 0.7, label=0)
+        t.record_prediction("d", 0.3, label=1)
+        t.record_prediction("e", 0.2, label=0)
+        t.record_prediction("f", 0.1, label=0)
+        snap = t.snapshot()
+        assert snap.tp == 2
+        assert snap.fp == 1
+        assert snap.fn == 1
+        assert snap.tn == 2
+        assert snap.precision == pytest.approx(2 / 3, abs=1e-6)
+        assert snap.recall == pytest.approx(2 / 3, abs=1e-6)
+        assert snap.f1 == pytest.approx(2 / 3, abs=1e-6)
+
+    def test_snapshot_windowing_filters_old_records(self):
+        t = PerformanceTracker()
+        old = datetime.now(timezone.utc) - timedelta(hours=2)
+        recent = datetime.now(timezone.utc)
+        t.record_prediction("old_1", 0.9, label=1, timestamp=old)
+        t.record_prediction("recent_1", 0.9, label=1, timestamp=recent)
+        # 1-hour window should only include the recent record.
+        snap = t.snapshot(window=timedelta(hours=1))
+        assert snap.n_total == 1
+        assert snap.n_labelled == 1
+
+    def test_snapshot_auroc_perfect_separation(self):
+        t = PerformanceTracker(threshold=0.5)
+        for i, lbl in enumerate([0, 0, 0, 1, 1, 1]):
+            t.record_prediction(f"tx_{i}", 0.1 + 0.15 * i, label=lbl)
+        snap = t.snapshot()
+        assert snap.auroc == pytest.approx(1.0, abs=1e-9)
+        assert snap.auprc == pytest.approx(1.0, abs=1e-9)
+
+    def test_snapshot_handles_single_class_labels(self):
+        t = PerformanceTracker()
+        for i in range(5):
+            t.record_prediction(f"tx_{i}", 0.5, label=0)
+        snap = t.snapshot()
+        # AUROC undefined with one class -> None.
+        assert snap.auroc is None
+        # AUPRC requires at least one positive -> None.
+        assert snap.auprc is None
+
+    def test_to_dict_round_trip(self):
+        t = PerformanceTracker()
+        t.record_prediction("tx_1", 0.9, label=1)
+        snap = t.snapshot()
+        d = snap.to_dict()
+        assert d["n_labelled"] == 1
+        assert isinstance(d["window_start"], str)
+        assert isinstance(d["generated_at"], str)
+
+    def test_thread_safety_can_be_locked(self):
+        # We don't run an actual race here but exercise the lock path.
+        t = PerformanceTracker()
+        t.record_prediction("tx_1", 0.5, label=1)
+        with t._lock:
+            assert t.n_records == 1

--- a/tests/unit/test_monitoring_registry.py
+++ b/tests/unit/test_monitoring_registry.py
@@ -1,0 +1,122 @@
+"""Unit tests for the monitoring Prometheus registry (Phase 7)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from fraud_detection.monitoring import (
+    DriftDetector,
+    MonitoringMetrics,
+    PerformanceSnapshot,
+    monitoring_metrics,
+)
+from fraud_detection.serving.middleware import metrics as serving_metrics
+
+
+def _drift_report():
+    rng = np.random.default_rng(11)
+    ref = {
+        "amount": rng.normal(loc=0, scale=1, size=400).tolist(),
+        "country": rng.choice(["US", "GB"], size=400).tolist(),
+    }
+    cur = {
+        "amount": rng.normal(loc=3, scale=1, size=400).tolist(),
+        "country": rng.choice(["US", "GB"], size=400).tolist(),
+    }
+    return DriftDetector(ref).detect(cur)
+
+
+class TestSingleton:
+    def test_module_level_singleton_is_a_monitoring_metrics(self):
+        assert isinstance(monitoring_metrics, MonitoringMetrics)
+
+
+class TestUpdaters:
+    def test_update_drift_runs_without_error(self):
+        report = _drift_report()
+        # Should not raise regardless of whether prometheus_client is installed.
+        monitoring_metrics.update_drift(report)
+
+    def test_update_drift_writes_overall_gauge_when_enabled(self):
+        if not serving_metrics.enabled:
+            return
+        report = _drift_report()
+        monitoring_metrics.update_drift(report)
+        rendered = serving_metrics.render().decode("utf-8")
+        assert "meshwatch_drift_psi_overall" in rendered
+
+    def test_update_drift_records_per_feature_gauges(self):
+        if not serving_metrics.enabled:
+            return
+        report = _drift_report()
+        monitoring_metrics.update_drift(report)
+        rendered = serving_metrics.render().decode("utf-8")
+        # At least one of the features should appear with a positive gauge.
+        assert "meshwatch_drift_psi_feature" in rendered
+
+    def test_update_performance_runs_without_error(self):
+        snap = PerformanceSnapshot(
+            n_total=10,
+            n_labelled=5,
+            precision=0.8,
+            recall=0.6,
+            f1=0.7,
+            auroc=0.9,
+            auprc=0.85,
+            threshold=0.7,
+        )
+        monitoring_metrics.update_performance(snap)
+
+    def test_update_performance_writes_gauges_when_enabled(self):
+        if not serving_metrics.enabled:
+            return
+        snap = PerformanceSnapshot(
+            n_total=10,
+            n_labelled=5,
+            precision=0.8,
+            recall=0.6,
+            f1=0.7,
+            auroc=0.9,
+            auprc=0.85,
+        )
+        monitoring_metrics.update_performance(snap)
+        rendered = serving_metrics.render().decode("utf-8")
+        assert "meshwatch_performance_precision" in rendered
+        assert "meshwatch_performance_recall" in rendered
+        assert "meshwatch_performance_f1" in rendered
+
+
+class TestAgentRecorder:
+    def test_record_agent_run_increments_counters(self):
+        # The no-op path should also not raise.
+        monitoring_metrics.record_agent_run(
+            risk_level="HIGH",
+            latency_seconds=0.42,
+            status="ok",
+            tool_calls=[("analyze_card_history", "ok"), ("retrieve_similar_cases", "ok")],
+        )
+
+    def test_record_agent_run_emits_metrics_when_enabled(self):
+        if not serving_metrics.enabled:
+            return
+        monitoring_metrics.record_agent_run(
+            risk_level="CRITICAL",
+            latency_seconds=1.23,
+            tool_calls=[("graph_walk", "ok")],
+        )
+        rendered = serving_metrics.render().decode("utf-8")
+        assert "meshwatch_agent_invocations_total" in rendered
+        assert "meshwatch_agent_run_latency_seconds" in rendered
+
+    def test_double_instantiation_is_safe(self):
+        # Constructing a second instance must not raise even though it
+        # would normally hit "Duplicated timeseries in CollectorRegistry".
+        another = MonitoringMetrics()
+        another.record_agent_run(risk_level="LOW", latency_seconds=0.01, tool_calls=[])
+
+    def test_update_drift_rejects_non_report(self):
+        # Passing a non-DriftReport should silently no-op rather than raise.
+        monitoring_metrics.update_drift("not a report")  # type: ignore[arg-type]
+
+    def test_update_performance_rejects_non_snapshot(self):
+        monitoring_metrics.update_performance({"precision": 0.9})  # type: ignore[arg-type]

--- a/tests/unit/test_monitoring_reports.py
+++ b/tests/unit/test_monitoring_reports.py
@@ -1,0 +1,84 @@
+"""Unit tests for the drift report serialisation helpers (Phase 7)."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from fraud_detection.monitoring.drift import DriftDetector
+from fraud_detection.monitoring.reports import (
+    report_to_html,
+    report_to_json,
+    write_html,
+    write_json,
+)
+
+
+def _make_report(rng):
+    ref = {
+        "amount": rng.normal(loc=50, scale=20, size=500).tolist(),
+        "country": rng.choice(["US", "GB"], size=500).tolist(),
+    }
+    cur = {
+        "amount": rng.normal(loc=500, scale=20, size=500).tolist(),  # severe drift
+        "country": rng.choice(["US", "GB"], size=500).tolist(),
+    }
+    return DriftDetector(ref).detect(cur)
+
+
+class TestJSON:
+    def test_report_to_json_is_valid_json(self):
+        rng = np.random.default_rng(7)
+        report = _make_report(rng)
+        payload = report_to_json(report)
+        parsed = json.loads(payload)
+        assert parsed["n_features"] == 2
+        assert "features" in parsed
+        assert parsed["severity"] in {"none", "moderate", "severe"}
+
+    def test_write_json_creates_file(self, tmp_path):
+        rng = np.random.default_rng(7)
+        report = _make_report(rng)
+        path = write_json(report, tmp_path / "drift.json")
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["n_features"] == 2
+
+
+class TestHTML:
+    def test_report_to_html_contains_summary(self):
+        rng = np.random.default_rng(7)
+        report = _make_report(rng)
+        html = report_to_html(report, title="Test report")
+        assert "<title>Test report</title>" in html
+        assert "Overall PSI" in html
+        assert "Severity" in html
+        # Severe drift should mark "amount" -- the severity badge class
+        # must be present somewhere in the table.
+        assert "severity" in html.lower()
+
+    def test_html_is_self_contained(self):
+        rng = np.random.default_rng(7)
+        report = _make_report(rng)
+        html = report_to_html(report)
+        # No external scripts / stylesheets -- we deliberately inline.
+        assert "<script" not in html
+        assert "<link" not in html
+        assert "<style>" in html  # inline CSS
+
+    def test_html_escapes_feature_names(self):
+        ref = {"<script>": [1.0, 2.0, 3.0]}
+        cur = {"<script>": [10.0, 20.0, 30.0]}
+        report = DriftDetector(ref, numeric_features=["<script>"]).detect(cur)
+        html = report_to_html(report)
+        # The raw "<script>" must be escaped.
+        assert "&lt;script&gt;" in html
+        assert "<script>" not in html.replace("<script", "").replace("script>", "")
+
+    def test_write_html_creates_file(self, tmp_path):
+        rng = np.random.default_rng(7)
+        report = _make_report(rng)
+        path = write_html(report, tmp_path / "drift.html")
+        assert path.exists()
+        assert path.read_text().startswith("<!doctype html>")

--- a/tests/unit/test_monitoring_shadow.py
+++ b/tests/unit/test_monitoring_shadow.py
@@ -1,0 +1,205 @@
+"""Unit tests for the shadow deployment (Phase 7)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from fraud_detection.monitoring.shadow import (
+    ShadowDecision,
+    ShadowDeployment,
+    ShadowSummary,
+)
+from fraud_detection.serving.schemas import FraudPrediction, TransactionRequest, risk_level
+
+
+class _FakePredictor:
+    """A deterministic predictor whose score depends only on amount.
+
+    Used by both champion and challenger -- by tweaking the slope we can
+    deterministically produce agreement / disagreement.
+    """
+
+    def __init__(self, *, slope: float, model_version: str, latency_ms: float = 0.0):
+        self.slope = float(slope)
+        self.model_version = model_version
+        self.latency_ms = float(latency_ms)
+        self.threshold = 0.7
+
+    def predict_one(self, req: TransactionRequest) -> FraudPrediction:
+        if self.latency_ms > 0:
+            time.sleep(self.latency_ms / 1000.0)
+        score = min(0.99, max(0.0, req.transaction_amt * self.slope))
+        return FraudPrediction(
+            transaction_id=req.transaction_id,
+            fraud_probability=score,
+            fraud_score=score,
+            risk_level=risk_level(score),
+            is_fraud_predicted=score >= self.threshold,
+            threshold=self.threshold,
+            top_features=[],
+            latency_ms={"total_ms": self.latency_ms},
+            model_version=self.model_version,
+        )
+
+
+def _req(tx_id: str, amt: float) -> TransactionRequest:
+    return TransactionRequest(
+        transaction_id=tx_id,
+        transaction_dt=1_000_000,
+        transaction_amt=amt,
+        product_cd="W",
+        card1=12345,
+    )
+
+
+@pytest.fixture
+def deployment():
+    champion = _FakePredictor(slope=0.005, model_version="champion-v1")
+    challenger = _FakePredictor(slope=0.005, model_version="challenger-v2")
+    d = ShadowDeployment(champion=champion, challenger=challenger, max_records=20)
+    yield d
+    d.shutdown(wait=True)
+
+
+class TestScoring:
+    def test_score_returns_champion_result(self, deployment):
+        result = deployment.score(_req("tx_1", 100))
+        # Champion slope 0.005 * 100 = 0.5
+        assert result.model_version == "champion-v1"
+        assert pytest.approx(result.fraud_score, abs=1e-6) == 0.5
+
+    def test_score_logs_challenger_decisions(self, deployment):
+        for i in range(5):
+            deployment.score(_req(f"tx_{i}", 100 + i))
+        # Wait briefly for the challenger to drain.
+        for _ in range(50):
+            if deployment.n_records >= 5:
+                break
+            time.sleep(0.02)
+        assert deployment.n_records == 5
+
+    def test_disabled_challenger_is_a_noop(self):
+        champion = _FakePredictor(slope=0.005, model_version="champion-v1")
+        d = ShadowDeployment(champion=champion, challenger=None)
+        try:
+            result = d.score(_req("tx_1", 100))
+            assert result.model_version == "champion-v1"
+            assert d.n_records == 0
+            assert d.enabled is False
+        finally:
+            d.shutdown(wait=True)
+
+
+class TestSummary:
+    def test_empty_summary_reports_zero_total(self, deployment):
+        summary = deployment.summary()
+        assert isinstance(summary, ShadowSummary)
+        assert summary.n_total == 0
+        assert summary.champion_model == "champion-v1"
+        assert summary.challenger_model == "challenger-v2"
+
+    def test_full_agreement_when_slopes_match(self, deployment):
+        for i in range(10):
+            deployment.score(_req(f"tx_{i}", 200 + i * 50))
+        # Drain background work.
+        for _ in range(100):
+            if deployment.n_records >= 10:
+                break
+            time.sleep(0.02)
+        summary = deployment.summary()
+        assert summary.n_total == 10
+        assert summary.agreement_rate == pytest.approx(1.0, abs=1e-9)
+        assert summary.mean_score_delta == pytest.approx(0.0, abs=1e-9)
+
+    def test_disagreement_when_slopes_diverge(self):
+        champion = _FakePredictor(slope=0.001, model_version="champion-v1")
+        challenger = _FakePredictor(slope=0.01, model_version="challenger-v2")
+        d = ShadowDeployment(champion=champion, challenger=challenger)
+        try:
+            for i in range(20):
+                d.score(_req(f"tx_{i}", 150 + i))  # straddles the 0.7 threshold
+            for _ in range(100):
+                if d.n_records >= 20:
+                    break
+                time.sleep(0.02)
+            summary = d.summary()
+            assert summary.n_disagreement > 0
+            assert summary.agreement_rate < 1.0
+            assert summary.max_score_delta > 0
+        finally:
+            d.shutdown(wait=True)
+
+
+class TestChallengerSafety:
+    def test_challenger_over_budget_is_skipped(self):
+        champion = _FakePredictor(slope=0.005, model_version="champion-v1")
+        slow = _FakePredictor(slope=0.005, model_version="slow-v2", latency_ms=150.0)
+        d = ShadowDeployment(
+            champion=champion, challenger=slow, challenger_budget_ms=50.0, max_records=10
+        )
+        try:
+            d.score(_req("tx_slow", 100))
+            # Wait long enough for the slow challenger to finish (150ms)
+            # plus our skip-logging path.
+            time.sleep(0.3)
+            summary = d.summary()
+            # The challenger finished but its latency exceeded the budget,
+            # so no record was kept.
+            assert summary.n_total == 0
+            assert summary.challenger_skipped >= 1
+        finally:
+            d.shutdown(wait=True)
+
+    def test_failing_challenger_is_counted(self):
+        class _Broken:
+            model_version = "broken-v2"
+            threshold = 0.7
+
+            def predict_one(self, _req):
+                raise RuntimeError("intentional failure")
+
+        champion = _FakePredictor(slope=0.005, model_version="champion-v1")
+        d = ShadowDeployment(champion=champion, challenger=_Broken())  # type: ignore[arg-type]
+        try:
+            d.score(_req("tx_1", 100))
+            time.sleep(0.1)
+            summary = d.summary()
+            assert summary.challenger_failed >= 1
+            assert summary.n_total == 0
+        finally:
+            d.shutdown(wait=True)
+
+    def test_attach_detach_challenger(self):
+        champion = _FakePredictor(slope=0.005, model_version="champion-v1")
+        d = ShadowDeployment(champion=champion, challenger=None)
+        try:
+            assert d.enabled is False
+            challenger = _FakePredictor(slope=0.005, model_version="challenger-v2")
+            d.attach_challenger(challenger)
+            assert d.enabled is True
+            d.detach_challenger()
+            assert d.enabled is False
+        finally:
+            d.shutdown(wait=True)
+
+
+class TestShadowDecisionRecord:
+    def test_decision_to_dict_serialises_timestamp(self):
+        decision = ShadowDecision(
+            transaction_id="tx_1",
+            champion_score=0.5,
+            challenger_score=0.75,
+            score_delta=0.25,
+            champion_label=False,
+            challenger_label=True,
+            agreement=False,
+            champion_model="champion-v1",
+            challenger_model="challenger-v2",
+            champion_latency_ms=1.0,
+            challenger_latency_ms=2.0,
+        )
+        d = decision.to_dict()
+        assert isinstance(d["timestamp"], str)
+        assert d["agreement"] is False


### PR DESCRIPTION
Drift detection, production performance tracking, Prometheus + Grafana, shadow deployment, and an extended CI surface -- closes Phase 7 of the implementation plan.

Drift detection (src/fraud_detection/monitoring/)
- drift.py: DriftDetector with PSI, KS, chi-square, Jensen-Shannon; pure-numpy + scipy stack with an optional Evidently bridge for the richer HTML report. Adds two extra helpers from the plan: label_drift (production fraud rate vs. training) and prediction_distribution_drift (score-distribution PSI).
- performance.py: PerformanceTracker is a bounded ring buffer of (score, label, timestamp) triples. Snapshot computes precision / recall / F1 / AUROC / AUPRC / Brier over any window; thread-safe so the FastAPI hot path can append while labels merge in from a background job. Pure-numpy fallback when sklearn isn't around.
- reports.py: self-contained HTML + JSON renderers for DriftReport. Inlined CSS, no JS, escapes feature names so untrusted column labels never produce XSS in the report.
- registry.py: extends the Phase 4 Prometheus registry with drift, performance, agent, label-drift, prediction-distribution-drift, and shadow-deployment collectors. Reuses the shared CollectorRegistry via _names_to_collectors so re-instantiation in tests is safe.
- alerts.py: AlertEvaluator + default_rules() mirror the Prometheus rules so the application surface (/api/v1/monitoring/alerts) reports the same conditions as the alertmanager would.
- shadow.py: ShadowDeployment runs the champion on the request thread and the challenger off a small ThreadPoolExecutor. Per- request ShadowDecision logs, rolling ShadowSummary, configurable budget (default 100ms) drops runaway challenger runs.

Prometheus rules (configs/prometheus_rules.yml)
Plan-mandated thresholds (page 11):
  HighLatency        P95 > 50ms          (the Phase 4 budget)
  FraudRateSpike     production > 10%    (training baseline 3.5%)
  DataDrift          > 10 features       drifted simultaneously
  ModelDegradation   AUPRC < 0.60        (training baseline 0.70)
Plus DataDriftSevere/Moderate, ModelPerformanceDegraded (recall),
LabelDriftHigh, PredictionDistributionDrift, AgentInvestigationsFailing,
ShadowChallengerDisagreement.

Grafana provisioning (configs/grafana/)
Four dashboards auto-loaded at boot:
  01_operational.json     RPS, latency, errors, alert volume,
                          production fraud rate vs. reference
  02_model_performance.json  PSI gauge, precision/recall/F1, AUROC
                             and AUPRC bands, label + prediction
                             drift
  03_agent_analytics.json  invocations/min, P95 latency by risk
                           level, top-tool bargauges, tool failures
  04_infrastructure.json   in-flight, shadow agreement, status code
                           stacks, score-delta heatmap
Datasource provisioning ships a default Prometheus datasource at
prometheus:9090; docker-compose mounts both directories into the
grafana container so a clean `docker compose up -d` lands operators
on live dashboards.

FastAPI surface (src/fraud_detection/serving/app.py)
- App version bumped to v0.7.0-mlops.
- /api/v1/monitoring/drift, /drift.html, /performance, /alerts, /shadow, /shadow/recent.
- POST /api/v1/monitoring/label attaches a chargeback label to a prior prediction so the rolling performance snapshot stays fresh.
- /predict + /predict/batch now feed the performance tracker; when a challenger is attached they route through ShadowDeployment instead of FraudPredictor directly.
- /investigate records meshwatch_agent_invocations_total + meshwatch_agent_tool_invocations_total + run-latency histogram.
- serving/__init__.py: rewritten as PEP 562 lazy attribute access to break a circular import between monitoring/__init__ and the eager app re-exports.

CLI + scripts
- scripts/monitor.py: click CLI that compares two parquet/CSV splits, writes drift.json + drift.html under --output-dir, prints the top-k offenders, updates the live Prometheus gauges, and (optional) logs a snapshot to the MLflow meshwatch-production experiment. Picks up isFraud / fraud_score columns automatically to emit label-drift and prediction-distribution-drift signals.
- Makefile: drift-report, drift-report-evidently, grafana-open, prometheus-open, tag-phase-7.

CI
- .github/workflows/ci.yml: split into three jobs. lint-and-test  Python matrix (3.10/3.11/3.12) + monitor extras
    dashboard      Node 20/22 type-check + vitest + production build
    integration    promtool check rules + dashboard JSON validation
                   + smoke probes against /health, /metrics, and
                   every /monitoring/* endpoint
- .github/workflows/promote-model.yml: manual workflow_dispatch that
  applies an MLflow registry alias. Reads the candidate run's
  test_auprc and refuses to promote below the 0.60 ModelDegradation
  floor; writes a markdown step summary.

Infrastructure
- docker-compose.yml: mounts configs/prometheus_rules.yml + configs/grafana/{provisioning,dashboards} into the prometheus and grafana containers.

Acceptance (plan page 11)
- Evidently drift                 yes (KS + PSI/KL + label drift)
- Prometheus metrics              yes (request count/latency/errors +
                                       score distribution + fraud
                                       rate + agent duration +
                                       shadow telemetry)
- 4 Grafana dashboards            yes (operational / model / agent /
                                       infrastructure)
- Shadow deploy                   yes (ShadowDeployment middleware +
                                       /api/v1/monitoring/shadow)
- CI/CD                           yes (lint -> unit tests ->
                                       integration smoke + manual
                                       model promotion workflow)
- Alerting                        yes (HighLatency P95>50ms,
                                       FraudRateSpike>10%, DataDrift
                                       >10 features,
                                       ModelDegradation AUPRC<0.60)

Tests + QA
- 104 new unit tests across drift, performance, reports, alerts, registry, shadow, monitor CLI, and the monitoring endpoints.
- Full suite: 403 unit tests passing, ruff lint + format clean.